### PR TITLE
treat listtype=set as set without ordering

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/each.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/each.go
@@ -95,7 +95,7 @@ func Unique[T comparable](_ context.Context, op operation.Operation, fldPath *fi
 // Unique, this function can be used with types that are not directly
 // comparable, at the cost of performance.
 func UniqueNonComparable[T any](_ context.Context, op operation.Operation, fldPath *field.Path, newSlice, _ []T) field.ErrorList {
-	return unique(fldPath, newSlice, func(a, b T) bool { return equality.Semantic.DeepEqual(a, b) })
+	return unique(fldPath, newSlice, SemanticDeepEqual)
 }
 
 // unique compares every element of the slice with every other element and
@@ -122,4 +122,15 @@ func unique[T any](fldPath *field.Path, slice []T, cmp func(T, T) bool) field.Er
 		errs = append(errs, field.Duplicate(fldPath.Index(i), slice[i]))
 	}
 	return errs
+}
+
+// SemanticDeepEqual is a CompareFunc that uses equality.Semantic.DeepEqual to
+// compare two values.
+// This wrapper is needed because CompareFunc requires a function that takes two
+// arguments of specific type T, while equality.Semantic.DeepEqual takes arguments
+// of type interface{}/any. The wrapper satisfies the type constraints of CompareFunc
+// while leveraging the underlying semantic equality logic.
+// It can be used by any other function that needs to call DeepEqual.
+func SemanticDeepEqual[T any](a, b T) bool {
+	return equality.Semantic.DeepEqual(a, b)
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listset/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listset/doc.go
@@ -40,6 +40,24 @@ type Struct struct {
 	SliceNonComparableField []NonComparableStruct `json:"sliceNonComparableField"`
 }
 
+type ImmutableStruct struct {
+	TypeMeta int
+
+	// +k8s:eachVal=+k8s:immutable
+	SliceComparableField []ComparableStruct `json:"sliceComparableField"`
+
+	// +k8s:listType=set
+	// +k8s:eachVal=+k8s:immutable
+	SliceSetComparableField []ComparableStruct `json:"sliceSetComparableField"`
+
+	// +k8s:eachVal=+k8s:immutable
+	SliceNonComparableField []NonComparableStruct `json:"sliceNonComparableField"`
+
+	// +k8s:listType=set
+	// +k8s:eachVal=+k8s:immutable
+	SliceSetNonComparableField []NonComparableStruct `json:"sliceSetNonComparableField"`
+}
+
 type ComparableStruct struct {
 	StringField string `json:"stringField"`
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listset/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listset/doc_test.go
@@ -74,3 +74,29 @@ func Test(t *testing.T) {
 		field.Duplicate(field.NewPath("sliceNonComparableField").Index(5), NonComparableStruct{[]string{"aaa", "111"}}),
 	)
 }
+
+func TestSetCorrelation(t *testing.T) {
+	st := localSchemeBuilder.Test(t)
+
+	structNew := ImmutableStruct{SliceComparableField: []ComparableStruct{{"aaa"}, {"bbb"}}}
+	structOld := ImmutableStruct{SliceComparableField: []ComparableStruct{{"bbb"}, {"aaa"}}}
+	st.Value(&structOld).OldValue(&structNew).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+		field.Forbidden(field.NewPath("sliceComparableField").Index(0), ""),
+		field.Forbidden(field.NewPath("sliceComparableField").Index(1), ""),
+	})
+
+	structNew = ImmutableStruct{SliceSetComparableField: []ComparableStruct{{"aaa"}, {"bbb"}}}
+	structOld = ImmutableStruct{SliceSetComparableField: []ComparableStruct{{"bbb"}, {"aaa"}}}
+	st.Value(&structOld).OldValue(&structNew).ExpectValid()
+
+	structNew = ImmutableStruct{SliceNonComparableField: []NonComparableStruct{{[]string{"aaa"}}, {[]string{"bbb"}}}}
+	structOld = ImmutableStruct{SliceNonComparableField: []NonComparableStruct{{[]string{"bbb"}}, {[]string{"aaa"}}}}
+	st.Value(&structOld).OldValue(&structNew).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+		field.Forbidden(field.NewPath("sliceNonComparableField").Index(0), ""),
+		field.Forbidden(field.NewPath("sliceNonComparableField").Index(1), ""),
+	})
+
+	structNew = ImmutableStruct{SliceSetNonComparableField: []NonComparableStruct{{[]string{"aaa"}}, {[]string{"bbb"}}}}
+	structOld = ImmutableStruct{SliceSetNonComparableField: []NonComparableStruct{{[]string{"bbb"}}, {[]string{"aaa"}}}}
+	st.Value(&structOld).OldValue(&structNew).ExpectValid()
+}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listset/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listset/zz_generated.validations.go
@@ -36,10 +36,49 @@ func init() { localSchemeBuilder.Register(RegisterValidations) }
 // RegisterValidations adds validation functions to the given scheme.
 // Public to allow building arbitrary schemes.
 func RegisterValidations(scheme *testscheme.Scheme) error {
+	scheme.AddValidationFunc((*ImmutableStruct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
+		return Validate_ImmutableStruct(ctx, op, nil /* fldPath */, obj.(*ImmutableStruct), safe.Cast[*ImmutableStruct](oldObj))
+	})
 	scheme.AddValidationFunc((*Struct)(nil), func(ctx context.Context, op operation.Operation, obj, oldObj interface{}) field.ErrorList {
 		return Validate_Struct(ctx, op, nil /* fldPath */, obj.(*Struct), safe.Cast[*Struct](oldObj))
 	})
 	return nil
+}
+
+func Validate_ImmutableStruct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *ImmutableStruct) (errs field.ErrorList) {
+	// field ImmutableStruct.TypeMeta has no validation
+
+	// field ImmutableStruct.SliceComparableField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []ComparableStruct) (errs field.ErrorList) {
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, validate.ImmutableByReflect)...)
+			return
+		}(fldPath.Child("sliceComparableField"), obj.SliceComparableField, safe.Field(oldObj, func(oldObj *ImmutableStruct) []ComparableStruct { return oldObj.SliceComparableField }))...)
+
+	// field ImmutableStruct.SliceSetComparableField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []ComparableStruct) (errs field.ErrorList) {
+			errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a ComparableStruct, b ComparableStruct) bool { return a == b }, validate.ImmutableByReflect)...)
+			return
+		}(fldPath.Child("sliceSetComparableField"), obj.SliceSetComparableField, safe.Field(oldObj, func(oldObj *ImmutableStruct) []ComparableStruct { return oldObj.SliceSetComparableField }))...)
+
+	// field ImmutableStruct.SliceNonComparableField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []NonComparableStruct) (errs field.ErrorList) {
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, validate.ImmutableByReflect)...)
+			return
+		}(fldPath.Child("sliceNonComparableField"), obj.SliceNonComparableField, safe.Field(oldObj, func(oldObj *ImmutableStruct) []NonComparableStruct { return oldObj.SliceNonComparableField }))...)
+
+	// field ImmutableStruct.SliceSetNonComparableField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj []NonComparableStruct) (errs field.ErrorList) {
+			errs = append(errs, validate.UniqueNonComparable(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, validate.SemanticDeepEqual, validate.ImmutableByReflect)...)
+			return
+		}(fldPath.Child("sliceSetNonComparableField"), obj.SliceSetNonComparableField, safe.Field(oldObj, func(oldObj *ImmutableStruct) []NonComparableStruct { return oldObj.SliceSetNonComparableField }))...)
+
+	return errs
 }
 
 func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
@@ -41,7 +41,7 @@ var globalEachKey *eachKeyTagValidator
 func init() {
 	// Lists with list-map semantics are comprised of multiple tags, which need
 	// to share information between them.
-	shared := map[string]*listMap{} // keyed by the fieldpath
+	shared := map[string]*listMetadata{} // keyed by the fieldpath
 	RegisterTagValidator(listTypeTagValidator{shared})
 	RegisterTagValidator(listMapKeyTagValidator{shared})
 
@@ -55,14 +55,14 @@ func init() {
 // This applies to all tags in this file.
 var listTagsValidScopes = sets.New(ScopeAny)
 
-// listMap collects information about a single list with map semantics.
-type listMap struct {
+// listMetadata collects information about a single list with map semantics.
+type listMetadata struct {
 	declaredAsMap bool
 	keyFields     []string
 }
 
 type listTypeTagValidator struct {
-	byFieldPath map[string]*listMap
+	byFieldPath map[string]*listMetadata
 }
 
 func (listTypeTagValidator) Init(Config) {}
@@ -104,7 +104,7 @@ func (lttv listTypeTagValidator) GetValidations(context Context, _ []string, pay
 
 		// Save the fact that this list is a map.
 		if lttv.byFieldPath[context.Path.String()] == nil {
-			lttv.byFieldPath[context.Path.String()] = &listMap{}
+			lttv.byFieldPath[context.Path.String()] = &listMetadata{}
 		}
 		lm := lttv.byFieldPath[context.Path.String()]
 		lm.declaredAsMap = true
@@ -131,7 +131,7 @@ func (lttv listTypeTagValidator) Docs() TagDoc {
 }
 
 type listMapKeyTagValidator struct {
-	byFieldPath map[string]*listMap
+	byFieldPath map[string]*listMetadata
 }
 
 func (listMapKeyTagValidator) Init(Config) {}
@@ -165,7 +165,7 @@ func (lmktv listMapKeyTagValidator) GetValidations(context Context, _ []string, 
 	}
 
 	if lmktv.byFieldPath[context.Path.String()] == nil {
-		lmktv.byFieldPath[context.Path.String()] = &listMap{}
+		lmktv.byFieldPath[context.Path.String()] = &listMetadata{}
 	}
 	lm := lmktv.byFieldPath[context.Path.String()]
 	lm.keyFields = append(lm.keyFields, fieldName)
@@ -189,7 +189,7 @@ func (lmktv listMapKeyTagValidator) Docs() TagDoc {
 }
 
 type eachValTagValidator struct {
-	byFieldPath map[string]*listMap
+	byFieldPath map[string]*listMetadata
 	validator   Validator
 }
 
@@ -265,7 +265,7 @@ func (evtv eachValTagValidator) getListValidations(fldPath *field.Path, t *types
 	result := Validations{}
 	result.OpaqueValType = validations.OpaqueType
 
-	var listMap *listMap
+	var listMetadata *listMetadata
 	if lm, found := evtv.byFieldPath[fldPath.String()]; found {
 		if !lm.declaredAsMap {
 			return Validations{}, fmt.Errorf("found listMapKey without listType=map")
@@ -273,11 +273,11 @@ func (evtv eachValTagValidator) getListValidations(fldPath *field.Path, t *types
 		if len(lm.keyFields) == 0 {
 			return Validations{}, fmt.Errorf("found listType=map without listMapKey")
 		}
-		listMap = lm
+		listMetadata = lm
 	}
 	for _, vfn := range validations.Functions {
 		var cmpArg any = Literal("nil")
-		if listMap != nil {
+		if listMetadata != nil {
 			cmpFn := FunctionLiteral{
 				Parameters: []ParamResult{{"a", t.Elem}, {"b", t.Elem}},
 				Results:    []ParamResult{{"", types.Bool}},
@@ -286,7 +286,7 @@ func (evtv eachValTagValidator) getListValidations(fldPath *field.Path, t *types
 			buf.WriteString("return ")
 			// Note: this does not handle pointer fields, which are not
 			// supposed to be used as listMap keys.
-			for i, fld := range listMap.keyFields {
+			for i, fld := range listMetadata.keyFields {
 				if i > 0 {
 					buf.WriteString(" && ")
 				}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
@@ -42,22 +42,24 @@ func init() {
 	// Lists with list-map semantics are comprised of multiple tags, which need
 	// to share information between them.
 	shared := map[string]*listMetadata{} // keyed by the fieldpath
-	RegisterTagValidator(listTypeTagValidator{shared})
-	RegisterTagValidator(listMapKeyTagValidator{shared})
+	RegisterTagValidator(listTypeTagValidator{byFieldPath: shared})
+	RegisterTagValidator(listMapKeyTagValidator{byFieldPath: shared})
 
-	globalEachVal = &eachValTagValidator{shared, nil}
+	globalEachVal = &eachValTagValidator{byFieldPath: shared, validator: nil}
 	RegisterTagValidator(globalEachVal)
 
-	globalEachKey = &eachKeyTagValidator{nil}
+	globalEachKey = &eachKeyTagValidator{validator: nil}
 	RegisterTagValidator(globalEachKey)
 }
 
 // This applies to all tags in this file.
 var listTagsValidScopes = sets.New(ScopeAny)
 
-// listMetadata collects information about a single list with map semantics.
+// listMetadata collects information about a single list with map or set semantics.
 type listMetadata struct {
+	// These will be checked for correctness elsewhere.
 	declaredAsMap bool
+	declaredAsSet bool
 	keyFields     []string
 }
 
@@ -91,6 +93,11 @@ func (lttv listTypeTagValidator) GetValidations(context Context, _ []string, pay
 	case "atomic":
 		// Allowed but no special handling.
 	case "set":
+		if lttv.byFieldPath[context.Path.String()] == nil {
+			lttv.byFieldPath[context.Path.String()] = &listMetadata{}
+		}
+		lm := lttv.byFieldPath[context.Path.String()]
+		lm.declaredAsSet = true
 		// NOTE: lists of pointers are not supported, so we should never see a pointer here.
 		if nativeType(t.Elem).IsComparable() {
 			return Validations{Functions: []FunctionGen{Function(listTypeTagName, DefaultFlags, validateUnique)}}, nil
@@ -210,8 +217,9 @@ func (eachValTagValidator) ValidScopes() sets.Set[Scope] {
 func (eachValTagValidator) LateTagValidator() {}
 
 var (
-	validateEachSliceVal = types.Name{Package: libValidationPkg, Name: "EachSliceVal"}
-	validateEachMapVal   = types.Name{Package: libValidationPkg, Name: "EachMapVal"}
+	validateEachSliceVal      = types.Name{Package: libValidationPkg, Name: "EachSliceVal"}
+	validateEachMapVal        = types.Name{Package: libValidationPkg, Name: "EachMapVal"}
+	validateSemanticDeepEqual = types.Name{Package: libValidationPkg, Name: "SemanticDeepEqual"}
 )
 
 func (evtv eachValTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
@@ -267,33 +275,54 @@ func (evtv eachValTagValidator) getListValidations(fldPath *field.Path, t *types
 
 	var listMetadata *listMetadata
 	if lm, found := evtv.byFieldPath[fldPath.String()]; found {
-		if !lm.declaredAsMap {
+		if lm.declaredAsSet && lm.declaredAsMap {
+			return Validations{}, fmt.Errorf("listType cannot be both set and map")
+		}
+		if lm.declaredAsMap && len(lm.keyFields) == 0 {
+			return Validations{}, fmt.Errorf("found listType=map without listMapKey")
+		}
+		if len(lm.keyFields) > 0 && !lm.declaredAsMap {
 			return Validations{}, fmt.Errorf("found listMapKey without listType=map")
 		}
-		if len(lm.keyFields) == 0 {
-			return Validations{}, fmt.Errorf("found listType=map without listMapKey")
+		// Check for missing listType (after the other checks so the more specific errors take priority)
+		if !lm.declaredAsSet && !lm.declaredAsMap {
+			return Validations{}, fmt.Errorf("found list metadata without a listType")
 		}
 		listMetadata = lm
 	}
+
 	for _, vfn := range validations.Functions {
 		var cmpArg any = Literal("nil")
 		if listMetadata != nil {
-			cmpFn := FunctionLiteral{
-				Parameters: []ParamResult{{"a", t.Elem}, {"b", t.Elem}},
-				Results:    []ParamResult{{"", types.Bool}},
-			}
-			buf := strings.Builder{}
-			buf.WriteString("return ")
-			// Note: this does not handle pointer fields, which are not
-			// supposed to be used as listMap keys.
-			for i, fld := range listMetadata.keyFields {
-				if i > 0 {
-					buf.WriteString(" && ")
+			if listMetadata.declaredAsMap {
+				cmpFn := FunctionLiteral{
+					Parameters: []ParamResult{{"a", t.Elem}, {"b", t.Elem}},
+					Results:    []ParamResult{{"", types.Bool}},
 				}
-				buf.WriteString(fmt.Sprintf("a.%s == b.%s", fld, fld))
+				buf := strings.Builder{}
+				buf.WriteString("return ")
+				// Note: this does not handle pointer fields, which are not
+				// supposed to be used as listMap keys.
+				for i, fld := range listMetadata.keyFields {
+					if i > 0 {
+						buf.WriteString(" && ")
+					}
+					buf.WriteString(fmt.Sprintf("a.%s == b.%s", fld, fld))
+				}
+				cmpFn.Body = buf.String()
+				cmpArg = cmpFn
+			} else if listMetadata.declaredAsSet {
+				elemType := nativeType(t.Elem)
+				if elemType.IsComparable() {
+					cmpArg = FunctionLiteral{
+						Parameters: []ParamResult{{"a", t.Elem}, {"b", t.Elem}},
+						Results:    []ParamResult{{"", types.Bool}},
+						Body:       "return a == b",
+					}
+				} else {
+					cmpArg = Identifier(validateSemanticDeepEqual)
+				}
 			}
-			cmpFn.Body = buf.String()
-			cmpArg = cmpFn
 		}
 		f := Function(eachValTagName, vfn.Flags, validateEachSliceVal, cmpArg, WrapperFunction{vfn, t.Elem})
 		result.Functions = append(result.Functions, f)


### PR DESCRIPTION
- identify listtype=set and store in shared listMetadata
- pass in cmp for lookup in eachVal
- update FunctionLiteral to pass in dependent packages

Migrate from https://github.com/jpbetz/kubernetes/pull/151