### PR TITLE
Implement listmap keys uniqueness

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/each.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/each.go
@@ -119,6 +119,13 @@ func UniqueByReflect[T any](_ context.Context, op operation.Operation, fldPath *
 	return unique(fldPath, newSlice, SemanticDeepEqual)
 }
 
+// UniqueByFunc verifies that each element in the list map is unique by using the provided comparison function.
+// The comparison function (cmp) determines when two elements are considered equal, and if any elements
+// are found to be equal according to this function, they are reported as duplicates.
+func UniqueByFunc[T any](_ context.Context, op operation.Operation, fldPath *field.Path, newSlice, _ []T, cmp CompareFunc[T]) field.ErrorList {
+	return unique(fldPath, newSlice, cmp)
+}
+
 // unique compares every element of the slice with every other element and
 // returns errors for non-unique items.
 func unique[T any](fldPath *field.Path, slice []T, cmp func(T, T) bool) field.ErrorList {

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/each_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/each_test.go
@@ -323,3 +323,27 @@ func testUniqueByReflect[T any](t *testing.T, name string, input []T, wantErrs i
 		}
 	})
 }
+
+type listItem struct {
+	key1 string
+	key2 string
+	val  string
+}
+
+func TestUniqueByFunc(t *testing.T) {
+	testUniqueByFunc(t, "valid", []listItem{{"key1", "key2", "val1"}, {"key1", "key2", "val2"}, {"key1", "key3", "val3"}}, 1)
+	testUniqueByFunc(t, "valid", []listItem{{"key1", "key2", "val1"}, {"key1", "key2", "val2"}, {"key1", "key2", "val3"}}, 2)
+	testUniqueByFunc(t, "valid", []listItem{{"key1", "key2", "val1"}, {"key3", "key4", "val2"}, {"key5", "key6", "val3"}}, 0)
+}
+
+func testUniqueByFunc(t *testing.T, name string, input []listItem, wantErrs int) {
+	t.Helper()
+	t.Run(name, func(t *testing.T) {
+		errs := UniqueByFunc(context.Background(), operation.Operation{}, field.NewPath("test"), input, nil, func(a listItem, b listItem) bool {
+			return a.key1 == b.key1 && a.key2 == b.key2
+		})
+		if len(errs) != wantErrs {
+			t.Errorf("expected %d errors, got %d: %s", wantErrs, len(errs), fmtErrs(errs))
+		}
+	})
+}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/cross_pkg/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/cross_pkg/zz_generated.validations.go
@@ -286,6 +286,7 @@ func Validate_T1(ctx context.Context, op operation.Operation, fldPath *field.Pat
 			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil // no changes
 			}
+			errs = append(errs, validate.UniqueByFunc(ctx, op, fldPath, obj, oldObj, func(a other.StructType, b other.StructType) bool { return a.StringField == b.StringField })...)
 			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "field T1.ListMapOfOtherStruct")...)
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a other.StructType, b other.StructType) bool { return a.StringField == b.StringField }, validate.DirectEqual, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *other.StructType) field.ErrorList {
 				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "field T1.SliceOfOtherStruct values")

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/list/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/list/zz_generated.validations.go
@@ -117,6 +117,7 @@ func Validate_StructSlice(ctx context.Context, op operation.Operation, fldPath *
 			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil // no changes
 			}
+			errs = append(errs, validate.UniqueByFunc(ctx, op, fldPath, obj, oldObj, func(a DirectComparableStructWithKey, b DirectComparableStructWithKey) bool { return a.Key == b.Key })...)
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a DirectComparableStructWithKey, b DirectComparableStructWithKey) bool { return a.Key == b.Key }, validate.DirectEqual, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *DirectComparableStructWithKey) field.ErrorList {
 				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field SliceStructWithKey[*]")
 			})...)
@@ -129,6 +130,7 @@ func Validate_StructSlice(ctx context.Context, op operation.Operation, fldPath *
 			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil // no changes
 			}
+			errs = append(errs, validate.UniqueByFunc(ctx, op, fldPath, obj, oldObj, func(a NonComparableStructWithKey, b NonComparableStructWithKey) bool { return a.Key == b.Key })...)
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a NonComparableStructWithKey, b NonComparableStructWithKey) bool { return a.Key == b.Key }, validate.SemanticDeepEqual, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *NonComparableStructWithKey) field.ErrorList {
 				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field SliceNonComparableStructWithKey[*]")
 			})...)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/doc_test.go
@@ -113,4 +113,20 @@ func Test(t *testing.T) {
 		field.Invalid(field.NewPath("listNonComparableField").Index(1), "", ""),
 	})
 	st.Value(&structC).OldValue(&structC2).ExpectValid()
+
+	// Invalid duplicate keys
+	structD := Struct{
+		ListField: []OtherStruct{
+			{"key1", 1, "one"},
+			{"key1", 1, "two"},
+		},
+		ListTypedefField: []OtherTypedefStruct{
+			{"key1", 1, "one"},
+			{"key1", 1, "two"},
+		},
+	}
+	st.Value(&structD).ExpectInvalid(
+		field.Duplicate(field.NewPath("listField").Index(1), structD.ListField[1]),
+		field.Duplicate(field.NewPath("listTypedefField").Index(1), structD.ListTypedefField[1]),
+	)
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/zz_generated.validations.go
@@ -57,6 +57,9 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil // no changes
 			}
+			errs = append(errs, validate.UniqueByFunc(ctx, op, fldPath, obj, oldObj, func(a OtherStruct, b OtherStruct) bool {
+				return a.Key1Field == b.Key1Field && a.Key2Field == b.Key2Field
+			})...)
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a OtherStruct, b OtherStruct) bool {
 				return a.Key1Field == b.Key1Field && a.Key2Field == b.Key2Field
 			}, validate.DirectEqual, validate.ImmutableByCompare)...)
@@ -69,6 +72,9 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil // no changes
 			}
+			errs = append(errs, validate.UniqueByFunc(ctx, op, fldPath, obj, oldObj, func(a OtherTypedefStruct, b OtherTypedefStruct) bool {
+				return a.Key1Field == b.Key1Field && a.Key2Field == b.Key2Field
+			})...)
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a OtherTypedefStruct, b OtherTypedefStruct) bool {
 				return a.Key1Field == b.Key1Field && a.Key2Field == b.Key2Field
 			}, validate.DirectEqual, validate.ImmutableByCompare)...)
@@ -81,6 +87,9 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil // no changes
 			}
+			errs = append(errs, validate.UniqueByFunc(ctx, op, fldPath, obj, oldObj, func(a OtherStruct, b OtherStruct) bool {
+				return a.Key1Field == b.Key1Field && a.Key2Field == b.Key2Field
+			})...)
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a OtherStruct, b OtherStruct) bool {
 				return a.Key1Field == b.Key1Field && a.Key2Field == b.Key2Field
 			}, validate.DirectEqual, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherStruct) field.ErrorList {
@@ -95,6 +104,9 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil // no changes
 			}
+			errs = append(errs, validate.UniqueByFunc(ctx, op, fldPath, obj, oldObj, func(a NonComparableStruct, b NonComparableStruct) bool {
+				return a.Key1Field == b.Key1Field && a.Key2Field == b.Key2Field
+			})...)
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a NonComparableStruct, b NonComparableStruct) bool {
 				return a.Key1Field == b.Key1Field && a.Key2Field == b.Key2Field
 			}, validate.SemanticDeepEqual, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *NonComparableStruct) field.ErrorList {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/doc_test.go
@@ -113,4 +113,20 @@ func Test(t *testing.T) {
 		field.Invalid(field.NewPath("listNonComparableField").Index(1), "", ""),
 	})
 	st.Value(&structC).OldValue(&structC2).ExpectValid()
+
+	// Invalid duplicate keys
+	structD := Struct{
+		ListField: []OtherStruct{
+			{"key1", "one"},
+			{"key1", "two"},
+		},
+		ListTypedefField: []OtherTypedefStruct{
+			{"key1", "one"},
+			{"key1", "two"},
+		},
+	}
+	st.Value(&structD).ExpectInvalid(
+		field.Duplicate(field.NewPath("listField").Index(1), structD.ListField[1]),
+		field.Duplicate(field.NewPath("listTypedefField").Index(1), structD.ListTypedefField[1]),
+	)
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/zz_generated.validations.go
@@ -57,6 +57,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil // no changes
 			}
+			errs = append(errs, validate.UniqueByFunc(ctx, op, fldPath, obj, oldObj, func(a OtherStruct, b OtherStruct) bool { return a.KeyField == b.KeyField })...)
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a OtherStruct, b OtherStruct) bool { return a.KeyField == b.KeyField }, validate.DirectEqual, validate.ImmutableByCompare)...)
 			return
 		}(fldPath.Child("listField"), obj.ListField, safe.Field(oldObj, func(oldObj *Struct) []OtherStruct { return oldObj.ListField }))...)
@@ -67,6 +68,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil // no changes
 			}
+			errs = append(errs, validate.UniqueByFunc(ctx, op, fldPath, obj, oldObj, func(a OtherTypedefStruct, b OtherTypedefStruct) bool { return a.KeyField == b.KeyField })...)
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a OtherTypedefStruct, b OtherTypedefStruct) bool { return a.KeyField == b.KeyField }, validate.DirectEqual, validate.ImmutableByCompare)...)
 			return
 		}(fldPath.Child("listTypedefField"), obj.ListTypedefField, safe.Field(oldObj, func(oldObj *Struct) []OtherTypedefStruct { return oldObj.ListTypedefField }))...)
@@ -77,6 +79,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil // no changes
 			}
+			errs = append(errs, validate.UniqueByFunc(ctx, op, fldPath, obj, oldObj, func(a OtherStruct, b OtherStruct) bool { return a.KeyField == b.KeyField })...)
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a OtherStruct, b OtherStruct) bool { return a.KeyField == b.KeyField }, validate.DirectEqual, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherStruct) field.ErrorList {
 				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListComparableField[*]")
 			})...)
@@ -89,6 +92,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil // no changes
 			}
+			errs = append(errs, validate.UniqueByFunc(ctx, op, fldPath, obj, oldObj, func(a NonComparableStruct, b NonComparableStruct) bool { return a.KeyField == b.KeyField })...)
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a NonComparableStruct, b NonComparableStruct) bool { return a.KeyField == b.KeyField }, validate.SemanticDeepEqual, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *NonComparableStruct) field.ErrorList {
 				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListNonComparableField[*]")
 			})...)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/zz_generated.validations.go
@@ -192,6 +192,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil // no changes
 			}
+			errs = append(errs, validate.UniqueByFunc(ctx, op, fldPath, obj, oldObj, func(a OtherStruct, b OtherStruct) bool { return a.StringField == b.StringField })...)
 			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListMapOfStructField")...)
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a OtherStruct, b OtherStruct) bool { return a.StringField == b.StringField }, validate.DirectEqual, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherStruct) field.ErrorList {
 				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListMapOfStructField vals")
@@ -206,6 +207,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil // no changes
 			}
+			errs = append(errs, validate.UniqueByFunc(ctx, op, fldPath, obj, oldObj, func(a OtherStruct, b OtherStruct) bool { return a.StringField == b.StringField })...)
 			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListMapOfOpaqueStructField")...)
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a OtherStruct, b OtherStruct) bool { return a.StringField == b.StringField }, validate.DirectEqual, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *OtherStruct) field.ErrorList {
 				return validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "field Struct.ListMapOfOpaqueStructField vals")

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/registry.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/registry.go
@@ -190,17 +190,20 @@ func (reg *registry) sortTagsIntoPhases(tags []codetags.Tag) [][]codetags.Tag {
 	})
 
 	// Now split them into phases.
-	phase0 := []codetags.Tag{} // regular tags
-	phase1 := []codetags.Tag{} // "late" tags
+	phase0 := []codetags.Tag{} // "early" tags
+	phase1 := []codetags.Tag{} // regular tags
+	phase2 := []codetags.Tag{} // "late" tags
 	for _, tn := range sortedTags {
 		tv := reg.tagValidators[tn.Name]
-		if _, ok := tv.(LateTagValidator); ok {
-			phase1 = append(phase1, tn)
-		} else {
+		if _, ok := tv.(EarlyTagValidator); ok {
 			phase0 = append(phase0, tn)
+		} else if _, ok := tv.(LateTagValidator); ok {
+			phase2 = append(phase2, tn)
+		} else {
+			phase1 = append(phase1, tn)
 		}
 	}
-	return [][]codetags.Tag{phase0, phase1}
+	return [][]codetags.Tag{phase0, phase1, phase2}
 }
 
 // Docs returns documentation for each tag in this registry.

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
@@ -52,6 +52,13 @@ type LateTagValidator interface {
 	LateTagValidator()
 }
 
+// EarlyTagValidator is an optional extension to TagValidator. Any TagValidator
+// which implements this interface will be evaluated before all TagValidators
+// which do not.
+type EarlyTagValidator interface {
+	EarlyTagValidator()
+}
+
 // TypeValidator describes a validator which runs on every type definition.
 type TypeValidator interface {
 	// Init initializes the implementation.  This will be called exactly once.


### PR DESCRIPTION
- Added UniqueByFunc to validate uniqueness of list items using a custom comparison function.
- Introduced test cases for UniqueByFunc in each_test.go to ensure correct functionality.
- Updated existing validation logic to utilize UniqueByFunc for various struct fields in generated validation files.
- Enhanced the validation framework to support early tag validation for improved processing order.

ref: https://github.com/jpbetz/validation-gen/issues/62