### PR TITLE
Best effort to directly compare by using IsDirectComparable

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/zz_generated.validations.go
@@ -54,7 +54,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			}
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a OtherStruct, b OtherStruct) bool {
 				return a.Key1Field == b.Key1Field && a.Key2Field == b.Key2Field
-			}, validate.ImmutableByReflect)...)
+			}, validate.ImmutableByCompare)...)
 			return
 		}(fldPath.Child("listField"), obj.ListField, safe.Field(oldObj, func(oldObj *Struct) []OtherStruct { return oldObj.ListField }))...)
 
@@ -66,7 +66,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			}
 			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a OtherTypedefStruct, b OtherTypedefStruct) bool {
 				return a.Key1Field == b.Key1Field && a.Key2Field == b.Key2Field
-			}, validate.ImmutableByReflect)...)
+			}, validate.ImmutableByCompare)...)
 			return
 		}(fldPath.Child("listTypedefField"), obj.ListTypedefField, safe.Field(oldObj, func(oldObj *Struct) []OtherTypedefStruct { return oldObj.ListTypedefField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/zz_generated.validations.go
@@ -52,7 +52,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil // no changes
 			}
-			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a OtherStruct, b OtherStruct) bool { return a.KeyField == b.KeyField }, validate.ImmutableByReflect)...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a OtherStruct, b OtherStruct) bool { return a.KeyField == b.KeyField }, validate.ImmutableByCompare)...)
 			return
 		}(fldPath.Child("listField"), obj.ListField, safe.Field(oldObj, func(oldObj *Struct) []OtherStruct { return oldObj.ListField }))...)
 
@@ -62,7 +62,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil // no changes
 			}
-			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a OtherTypedefStruct, b OtherTypedefStruct) bool { return a.KeyField == b.KeyField }, validate.ImmutableByReflect)...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, func(a OtherTypedefStruct, b OtherTypedefStruct) bool { return a.KeyField == b.KeyField }, validate.ImmutableByCompare)...)
 			return
 		}(fldPath.Child("listTypedefField"), obj.ListTypedefField, safe.Field(oldObj, func(oldObj *Struct) []OtherTypedefStruct { return oldObj.ListTypedefField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listset/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listset/zz_generated.validations.go
@@ -55,7 +55,7 @@ func Validate_ImmutableStruct(ctx context.Context, op operation.Operation, fldPa
 			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil // no changes
 			}
-			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, validate.ImmutableByReflect)...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, nil, validate.ImmutableByCompare)...)
 			return
 		}(fldPath.Child("sliceComparableField"), obj.SliceComparableField, safe.Field(oldObj, func(oldObj *ImmutableStruct) []ComparableStruct { return oldObj.SliceComparableField }))...)
 
@@ -66,7 +66,7 @@ func Validate_ImmutableStruct(ctx context.Context, op operation.Operation, fldPa
 				return nil // no changes
 			}
 			errs = append(errs, validate.UniqueByCompare(ctx, op, fldPath, obj, oldObj)...)
-			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, validate.DirectEqual, validate.ImmutableByReflect)...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, validate.DirectEqual, validate.ImmutableByCompare)...)
 			return
 		}(fldPath.Child("sliceSetComparableField"), obj.SliceSetComparableField, safe.Field(oldObj, func(oldObj *ImmutableStruct) []ComparableStruct { return oldObj.SliceSetComparableField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listset/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listset/zz_generated.validations.go
@@ -65,8 +65,8 @@ func Validate_ImmutableStruct(ctx context.Context, op operation.Operation, fldPa
 			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil // no changes
 			}
-			errs = append(errs, validate.UniqueByReflect(ctx, op, fldPath, obj, oldObj)...)
-			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, validate.SemanticDeepEqual, validate.ImmutableByReflect)...)
+			errs = append(errs, validate.UniqueByCompare(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, validate.DirectEqual, validate.ImmutableByReflect)...)
 			return
 		}(fldPath.Child("sliceSetComparableField"), obj.SliceSetComparableField, safe.Field(oldObj, func(oldObj *ImmutableStruct) []ComparableStruct { return oldObj.SliceSetComparableField }))...)
 
@@ -155,7 +155,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil // no changes
 			}
-			errs = append(errs, validate.UniqueByReflect(ctx, op, fldPath, obj, oldObj)...)
+			errs = append(errs, validate.UniqueByCompare(ctx, op, fldPath, obj, oldObj)...)
 			return
 		}(fldPath.Child("sliceComparableField"), obj.SliceComparableField, safe.Field(oldObj, func(oldObj *Struct) []ComparableStruct { return oldObj.SliceComparableField }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
@@ -1100,7 +1100,7 @@ func emitRatchetingCheck(c *generator.Context, t *types.Type, sw *generator.Snip
 		"operation": mkSymbolArgs(c, operationPkgSymbols),
 	}
 	// If the type is a builtin, we can use a simpler equality check when they are not nil.
-	if isDirectComparable(validators.NonPointer(validators.NativeType(t))) {
+	if validators.IsDirectComparable(validators.NonPointer(validators.NativeType(t))) {
 		_, exprPfx, _ := getLeafTypeAndPrefixes(t)
 		targs["exprPfx"] = exprPfx
 		sw.Do("if op.Type == $.operation.Update|raw$ && (obj == oldObj || (obj != nil && oldObj != nil && $.exprPfx$obj == $.exprPfx$oldObj)) {\n", targs)
@@ -1499,27 +1499,4 @@ func (g *fixtureTestGen) Init(c *generator.Context, w io.Writer) error {
 		sw.Do("}\n", nil)
 	}
 	return nil
-}
-
-// isDirectComparable returns true if the type is safe to compare using "==".
-// It is similar to gengo.IsComparable, but is doesn't consider Pointers
-// as comparable.
-// This would be used for validation ratcheting to check whether this type can directly be compared.
-func isDirectComparable(t *types.Type) bool {
-	switch t.Kind {
-	case types.Builtin:
-		return true
-	case types.Struct:
-		for _, f := range t.Members {
-			if !isDirectComparable(f.Type) {
-				return false
-			}
-		}
-		return true
-	case types.Array:
-		return isDirectComparable(t.Elem)
-	case types.Alias:
-		return isDirectComparable(t.Underlying)
-	}
-	return false
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation_test.go
@@ -64,18 +64,6 @@ func mapOf(t *types.Type) *types.Type {
 	}
 }
 
-func arrayOf(t *types.Type) *types.Type {
-	return &types.Type{
-		Name: types.Name{
-			Package: "",
-			Name:    "[2]" + t.Name.String(),
-		},
-		Kind: types.Array,
-		Len:  2,
-		Elem: t,
-	}
-}
-
 func aliasOf(name string, t *types.Type) *types.Type {
 	return &types.Type{
 		Name: types.Name{
@@ -382,78 +370,6 @@ func TestGetLeafTypeAndPrefixes(t *testing.T) {
 		}
 		if got, want := exprPfx, tc.expectedExprPfx; got != want {
 			t.Errorf("%q: wrong expr prefix: expected %q, got %q", tc.in, want, got)
-		}
-	}
-}
-
-func TestIsDirectComparable(t *testing.T) {
-	cases := []struct {
-		in     *types.Type
-		expect bool
-	}{
-		{
-			in:     stringType,
-			expect: true,
-		}, {
-			in:     ptrTo(stringType),
-			expect: false,
-		}, {
-			in:     sliceOf(stringType),
-			expect: false,
-		}, {
-			in:     mapOf(stringType),
-			expect: false,
-		}, {
-			in:     aliasOf("s", stringType),
-			expect: true,
-		}, {
-			in: &types.Type{
-				Name: types.Name{
-					Package: "",
-					Name:    "struct_comparable_member",
-				},
-				Kind: types.Struct,
-				Members: []types.Member{
-					{
-						Name: "s",
-						Type: stringType,
-					},
-				},
-			},
-			expect: true,
-		}, {
-			in: &types.Type{
-				Name: types.Name{
-					Package: "",
-					Name:    "struct_uncomparable_member",
-				},
-				Kind: types.Struct,
-				Members: []types.Member{
-					{
-						Name: "s",
-						Type: ptrTo(stringType),
-					},
-				},
-			},
-			expect: false,
-		}, {
-			in:     arrayOf(stringType),
-			expect: true,
-		}, {
-			in:     arrayOf(aliasOf("s", stringType)),
-			expect: true,
-		}, {
-			in:     arrayOf(ptrTo(stringType)),
-			expect: false,
-		}, {
-			in:     arrayOf(mapOf(stringType)),
-			expect: false,
-		},
-	}
-
-	for _, tc := range cases {
-		if got, want := isDirectComparable(tc.in), tc.expect; got != want {
-			t.Errorf("%q: expected %v, got %v", tc.in, want, got)
 		}
 	}
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/common.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/common.go
@@ -104,3 +104,26 @@ func rootTypeString(src, dst *types.Type) string {
 	}
 	return src.String() + " -> " + dst.String()
 }
+
+// IsDirectComparable returns true if the type is safe to compare using "==".
+// It is similar to gengo.IsComparable, but is doesn't consider Pointers
+// as comparable.
+// This would be used for validation ratcheting to check whether this type can directly be compared.
+func IsDirectComparable(t *types.Type) bool {
+	switch t.Kind {
+	case types.Builtin:
+		return true
+	case types.Struct:
+		for _, f := range t.Members {
+			if !IsDirectComparable(f.Type) {
+				return false
+			}
+		}
+		return true
+	case types.Array:
+		return IsDirectComparable(t.Elem)
+	case types.Alias:
+		return IsDirectComparable(t.Underlying)
+	}
+	return false
+}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/common_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/common_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package validators
+
+import (
+	"testing"
+
+	"k8s.io/gengo/v2/types"
+)
+
+var stringType = &types.Type{
+	Name: types.Name{
+		Package: "",
+		Name:    "string",
+	},
+	Kind: types.Builtin,
+}
+
+func ptrTo(t *types.Type) *types.Type {
+	return &types.Type{
+		Name: types.Name{
+			Package: "",
+			Name:    "*" + t.Name.String(),
+		},
+		Kind: types.Pointer,
+		Elem: t,
+	}
+}
+
+func sliceOf(t *types.Type) *types.Type {
+	return &types.Type{
+		Name: types.Name{
+			Package: "",
+			Name:    "[]" + t.Name.String(),
+		},
+		Kind: types.Slice,
+		Elem: t,
+	}
+}
+
+func mapOf(t *types.Type) *types.Type {
+	return &types.Type{
+		Name: types.Name{
+			Package: "",
+			Name:    "map[string]" + t.Name.String(),
+		},
+		Kind: types.Map,
+		Key:  stringType,
+		Elem: t,
+	}
+}
+
+func arrayOf(t *types.Type) *types.Type {
+	return &types.Type{
+		Name: types.Name{
+			Package: "",
+			Name:    "[2]" + t.Name.String(),
+		},
+		Kind: types.Array,
+		Len:  2,
+		Elem: t,
+	}
+}
+
+func aliasOf(name string, t *types.Type) *types.Type {
+	return &types.Type{
+		Name: types.Name{
+			Package: "",
+			Name:    "Alias_" + name,
+		},
+		Kind:       types.Alias,
+		Underlying: t,
+	}
+}
+
+func TestIsDirectComparable(t *testing.T) {
+	cases := []struct {
+		in     *types.Type
+		expect bool
+	}{
+		{
+			in:     stringType,
+			expect: true,
+		}, {
+			in:     ptrTo(stringType),
+			expect: false,
+		}, {
+			in:     sliceOf(stringType),
+			expect: false,
+		}, {
+			in:     mapOf(stringType),
+			expect: false,
+		}, {
+			in:     aliasOf("s", stringType),
+			expect: true,
+		}, {
+			in: &types.Type{
+				Name: types.Name{
+					Package: "",
+					Name:    "struct_comparable_member",
+				},
+				Kind: types.Struct,
+				Members: []types.Member{
+					{
+						Name: "s",
+						Type: stringType,
+					},
+				},
+			},
+			expect: true,
+		}, {
+			in: &types.Type{
+				Name: types.Name{
+					Package: "",
+					Name:    "struct_uncomparable_member",
+				},
+				Kind: types.Struct,
+				Members: []types.Member{
+					{
+						Name: "s",
+						Type: ptrTo(stringType),
+					},
+				},
+			},
+			expect: false,
+		}, {
+			in:     arrayOf(stringType),
+			expect: true,
+		}, {
+			in:     arrayOf(aliasOf("s", stringType)),
+			expect: true,
+		}, {
+			in:     arrayOf(ptrTo(stringType)),
+			expect: false,
+		}, {
+			in:     arrayOf(mapOf(stringType)),
+			expect: false,
+		},
+	}
+
+	for _, tc := range cases {
+		if got, want := IsDirectComparable(tc.in), tc.expect; got != want {
+			t.Errorf("%q: expected %v, got %v", tc.in, want, got)
+		}
+	}
+}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
@@ -103,7 +103,7 @@ func (lttv listTypeTagValidator) GetValidations(context Context, _ []string, pay
 		// comparable but not what we need.
 		//
 		// NOTE: lists of pointers are not supported, so we should never see a pointer here.
-		if NonPointer(NativeType(t.Elem)).Kind == types.Builtin {
+		if IsDirectComparable(NonPointer(NativeType(t.Elem))) {
 			return Validations{Functions: []FunctionGen{Function(listTypeTagName, DefaultFlags, validateUniqueByCompare)}}, nil
 		}
 		return Validations{Functions: []FunctionGen{Function(listTypeTagName, DefaultFlags, validateUniqueByReflect)}}, nil
@@ -322,7 +322,7 @@ func (evtv eachValTagValidator) getListValidations(fldPath *field.Path, t *types
 				// pointer fields, which are directly comparable but not what we need.
 				//
 				// Note: This compares the pointee, not the pointer itself.
-				if NonPointer(NativeType(t.Elem)).Kind == types.Builtin {
+				if IsDirectComparable(NonPointer(NativeType(t.Elem))) {
 					cmpArg = Identifier(validateDirectEqual)
 				} else {
 					cmpArg = Identifier(validateSemanticDeepEqual)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/immutable.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/immutable.go
@@ -51,7 +51,7 @@ var (
 func (immutableTagValidator) GetValidations(context Context, _ []string, payload string) (Validations, error) {
 	var result Validations
 
-	if NonPointer(NativeType(context.Type)).Kind == types.Builtin {
+	if IsDirectComparable(NonPointer(NativeType(context.Type))) {
 		// This is a minor optimization to just compare primitive values when
 		// possible. Slices and maps are not comparable, and structs might hold
 		// pointer fields, which are directly comparable but not what we need.


### PR DESCRIPTION
Structs with all its fields comparable (not pointers), should be able to be compared directly with "==". 
- Move IsDirectComparable(T types.Type) into validators package.
- Apply on "each" tag validator.
- Apply on "immutable" tag validator.