### PR TITLE
feat: change +k8s:unionMember and +k8s:unionDiscriminator to use field extractors instead of being passed the values directly

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/union.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/union.go
@@ -68,7 +68,7 @@ func Union[T any](_ context.Context, op operation.Operation, fldPath *field.Path
 	}
 	if len(specifiedFields) == 0 {
 		return field.ErrorList{field.Invalid(fldPath, "",
-			fmt.Sprintf("must specify exactly one of: %s",
+			fmt.Sprintf("must specify one of: %s",
 				strings.Join(union.allFields(), ", ")))}
 	}
 	return nil

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/union.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/union.go
@@ -26,6 +26,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
+// ExtractorFn extracts a member field from a parent object.
+type ExtractorFn[T any] func(obj T) any
+
 // Union verifies that exactly one member of a union is specified.
 //
 // UnionMembership must define all the members of the union.
@@ -34,33 +37,36 @@ import (
 //
 //	var abcUnionMembership := schema.NewUnionMembership("a", "b", "c")
 //	func ValidateABC(ctx context.Context, op operation.Operation, fldPath *field.Path, in *ABC) (errs fields.ErrorList) {
-//		errs = append(errs, Union(ctx, op, fldPath, in, abcUnionMembership, in.A, in.B, in.C)...)
+//		errs = append(errs, Union(ctx, op, fldPath, in, oldIn, abcUnionMembership,
+//			func(in *ABC) any { return in.A },
+//			func(in *ABC) any { return in.B },
+//			func(in *ABC) any { return in.C },
+//		)...)
 //		return errs
 //	}
-func Union(_ context.Context, op operation.Operation, fldPath *field.Path, _, _ any, union *UnionMembership, fieldValues ...any) field.ErrorList {
-	if len(union.members) != len(fieldValues) {
+func Union[T any](_ context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj T, union *UnionMembership, extractorFns ...ExtractorFn[T]) field.ErrorList {
+	if len(union.members) != len(extractorFns) {
 		return field.ErrorList{
 			field.InternalError(fldPath,
-				fmt.Errorf("number of field values (%d) does not match number of union members (%d)",
-					len(fieldValues), len(union.members))),
+				fmt.Errorf("number of field extractors (%d) does not match number of union members (%d)",
+					len(extractorFns), len(union.members))),
 		}
 	}
-	var specifiedMember *string
-	for i, fieldValue := range fieldValues {
+	var specifiedFields []string
+	for i, extractor := range extractorFns {
+		fieldValue := extractor(obj)
 		rv := reflect.ValueOf(fieldValue)
 		if rv.IsValid() && !rv.IsZero() {
-			m := union.members[i]
-			if specifiedMember != nil && *specifiedMember != m.discriminatorValue {
-				return field.ErrorList{
-					field.Invalid(fldPath, fmt.Sprintf("{%s}", strings.Join(union.specifiedFields(fieldValues), ", ")),
-						fmt.Sprintf("must specify exactly one of: %s", strings.Join(union.allFields(), ", "))),
-				}
-			}
-			name := m.discriminatorValue
-			specifiedMember = &name
+			specifiedFields = append(specifiedFields, union.members[i].fieldName)
 		}
 	}
-	if specifiedMember == nil {
+	if len(specifiedFields) > 1 {
+		return field.ErrorList{
+			field.Invalid(fldPath, fmt.Sprintf("{%s}", strings.Join(specifiedFields, ", ")),
+				fmt.Sprintf("must specify exactly one of: %s", strings.Join(union.allFields(), ", "))),
+		}
+	}
+	if len(specifiedFields) == 0 {
 		return field.ErrorList{field.Invalid(fldPath, "",
 			fmt.Sprintf("must specify exactly one of: %s",
 				strings.Join(union.allFields(), ", ")))}
@@ -76,24 +82,39 @@ func Union(_ context.Context, op operation.Operation, fldPath *field.Path, _, _ 
 //
 //	var abcUnionMembership := schema.NewDiscriminatedUnionMembership("type", "a", "b", "c")
 //	func ValidateABC(ctx context.Context, op operation.Operation, fldPath, *field.Path, in *ABC) (errs fields.ErrorList) {
-//		errs = append(errs, DiscriminatedUnion(ctx, op, fldPath, in, abcUnionMembership, in.Type, in.A, in.B, in.C)...)
+//		errs = append(errs, DiscriminatedUnion(ctx, op, fldPath, in, oldIn, abcUnionMembership, in.Type,
+//			func(in *ABC) any { return in.A },
+//			func(in *ABC) any { return in.B },
+//			func(in *ABC) any { return in.C },
+//		)...)
 //		return errs
 //	}
 //
 // It is not an error for the discriminatorValue to be unknown.  That must be
 // validated on its own.
-func DiscriminatedUnion[T ~string](_ context.Context, op operation.Operation, fldPath *field.Path, _, _ any, union *UnionMembership, discriminatorValue T, fieldValues ...any) (errs field.ErrorList) {
-	discriminatorStrValue := string(discriminatorValue)
-	if len(union.members) != len(fieldValues) {
+func DiscriminatedUnion[T any](_ context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj T, union *UnionMembership, discriminatorExtractor ExtractorFn[T], extractorFns ...ExtractorFn[T]) (errs field.ErrorList) {
+	if len(union.members) != len(extractorFns) {
 		return field.ErrorList{
 			field.InternalError(fldPath,
-				fmt.Errorf("number of field values (%d) does not match number of union members (%d)",
-					len(fieldValues), len(union.members))),
+				fmt.Errorf("number of field extractors (%d) does not match number of union members (%d)",
+					len(extractorFns), len(union.members))),
 		}
 	}
-	for i, fieldValue := range fieldValues {
+
+	discriminatorValue := discriminatorExtractor(obj)
+	// Reflect to get string value through aliases, necessary for == comparison.
+	discriminatorStrValue := ""
+	if discriminatorValue != nil {
+		val := reflect.ValueOf(discriminatorValue)
+		if val.Kind() == reflect.String {
+			discriminatorStrValue = val.String()
+		}
+	}
+
+	for i, extractor := range extractorFns {
 		member := union.members[i]
 		isDiscriminatedMember := discriminatorStrValue == member.discriminatorValue
+		fieldValue := extractor(obj)
 		rv := reflect.ValueOf(fieldValue)
 		isSpecified := rv.IsValid() && !rv.IsZero()
 		if isSpecified && !isDiscriminatedMember {
@@ -136,19 +157,6 @@ func NewDiscriminatedUnionMembership(discriminatorFieldName string, members ...[
 		u.members = append(u.members, member{fieldName: fieldName[0], discriminatorValue: fieldName[1]})
 	}
 	return u
-}
-
-// specifiedFields returns a string listing all the field names of the specified fieldValues for use in error reporting.
-func (u UnionMembership) specifiedFields(fieldValues []any) []string {
-	var membersSpecified []string
-	for i, fieldValue := range fieldValues {
-		rv := reflect.ValueOf(fieldValue)
-		if rv.IsValid() && !rv.IsZero() {
-			f := u.members[i]
-			membersSpecified = append(membersSpecified, f.fieldName)
-		}
-	}
-	return membersSpecified
 }
 
 // allFields returns a string listing all the field names of the member of a union for use in error reporting.

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/union_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/union_test.go
@@ -74,13 +74,13 @@ func TestUnion(t *testing.T) {
 			name:        "invalid no member set",
 			fields:      [][2]string{{"a", "A"}, {"b", "B"}, {"c", "C"}, {"d", "D"}},
 			fieldValues: []any{nil, nil, nil, nil},
-			expected:    field.ErrorList{field.Invalid(nil, "", "must specify exactly one of: `a`, `b`, `c`, `d`")},
+			expected:    field.ErrorList{field.Invalid(nil, "", "must specify one of: `a`, `b`, `c`, `d`")},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			extractors := make([]ExtractorFn[*testMember], len(tc.fieldValues))
+			extractors := make([]ExtractorFn[*testMember, any], len(tc.fieldValues))
 			for i, val := range tc.fieldValues {
 				val := val
 				extractors[i] = func(_ *testMember) any { return val }
@@ -125,9 +125,9 @@ func TestDiscriminatedUnion(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			discriminatorExtractor := func(_ *testMember) any { return tc.discriminatorValue }
+			discriminatorExtractor := func(_ *testMember) string { return tc.discriminatorValue }
 
-			extractors := make([]ExtractorFn[*testMember], len(tc.fieldValues))
+			extractors := make([]ExtractorFn[*testMember, any], len(tc.fieldValues))
 			for i, val := range tc.fieldValues {
 				val := val
 				extractors[i] = func(_ *testMember) any { return val }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/custom_members/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/custom_members/zz_generated.validations.go
@@ -55,7 +55,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 		return nil // no changes
 	}
-	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, obj.D, obj.M1, obj.M2)...)
+	errs = append(errs, validate.DiscriminatedUnion[*Struct](ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) any { return obj.D }, func(obj *Struct) any { return obj.M1 }, func(obj *Struct) any { return obj.M2 })...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.D has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/custom_members/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/custom_members/zz_generated.validations.go
@@ -55,7 +55,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 		return nil // no changes
 	}
-	errs = append(errs, validate.DiscriminatedUnion[*Struct](ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) any { return obj.D }, func(obj *Struct) any { return obj.M1 }, func(obj *Struct) any { return obj.M2 })...)
+	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) any { return obj.D }, func(obj *Struct) any { return obj.M1 }, func(obj *Struct) any { return obj.M2 })...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.D has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/custom_members/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/custom_members/zz_generated.validations.go
@@ -55,7 +55,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 		return nil // no changes
 	}
-	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) any { return obj.D }, func(obj *Struct) any { return obj.M1 }, func(obj *Struct) any { return obj.M2 })...)
+	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) string { return string(obj.D) }, func(obj *Struct) any { return obj.M1 }, func(obj *Struct) any { return obj.M2 })...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.D has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/empty/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/empty/zz_generated.validations.go
@@ -54,7 +54,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	if op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
 		return nil // no changes
 	}
-	errs = append(errs, validate.DiscriminatedUnion[*Struct](ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) any { return obj.D })...)
+	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) any { return obj.D })...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.D has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/empty/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/empty/zz_generated.validations.go
@@ -54,7 +54,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	if op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
 		return nil // no changes
 	}
-	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, obj.D)...)
+	errs = append(errs, validate.DiscriminatedUnion[*Struct](ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) any { return obj.D })...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.D has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/empty/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/empty/zz_generated.validations.go
@@ -54,7 +54,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	if op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
 		return nil // no changes
 	}
-	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) any { return obj.D })...)
+	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) string { return string(obj.D) })...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.D has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/multiple/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/multiple/zz_generated.validations.go
@@ -56,8 +56,8 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 		return nil // no changes
 	}
-	errs = append(errs, validate.DiscriminatedUnion[*Struct](ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion1, func(obj *Struct) any { return obj.D1 }, func(obj *Struct) any { return obj.U1M1 }, func(obj *Struct) any { return obj.U1M2 })...)
-	errs = append(errs, validate.DiscriminatedUnion[*Struct](ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion2, func(obj *Struct) any { return obj.D2 }, func(obj *Struct) any { return obj.U2M1 }, func(obj *Struct) any { return obj.U2M2 })...)
+	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion1, func(obj *Struct) any { return obj.D1 }, func(obj *Struct) any { return obj.U1M1 }, func(obj *Struct) any { return obj.U1M2 })...)
+	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion2, func(obj *Struct) any { return obj.D2 }, func(obj *Struct) any { return obj.U2M1 }, func(obj *Struct) any { return obj.U2M2 })...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.D1 has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/multiple/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/multiple/zz_generated.validations.go
@@ -56,8 +56,8 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 		return nil // no changes
 	}
-	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion1, obj.D1, obj.U1M1, obj.U1M2)...)
-	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion2, obj.D2, obj.U2M1, obj.U2M2)...)
+	errs = append(errs, validate.DiscriminatedUnion[*Struct](ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion1, func(obj *Struct) any { return obj.D1 }, func(obj *Struct) any { return obj.U1M1 }, func(obj *Struct) any { return obj.U1M2 })...)
+	errs = append(errs, validate.DiscriminatedUnion[*Struct](ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion2, func(obj *Struct) any { return obj.D2 }, func(obj *Struct) any { return obj.U2M1 }, func(obj *Struct) any { return obj.U2M2 })...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.D1 has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/multiple/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/multiple/zz_generated.validations.go
@@ -56,8 +56,8 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 		return nil // no changes
 	}
-	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion1, func(obj *Struct) any { return obj.D1 }, func(obj *Struct) any { return obj.U1M1 }, func(obj *Struct) any { return obj.U1M2 })...)
-	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion2, func(obj *Struct) any { return obj.D2 }, func(obj *Struct) any { return obj.U2M1 }, func(obj *Struct) any { return obj.U2M2 })...)
+	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion1, func(obj *Struct) string { return string(obj.D1) }, func(obj *Struct) any { return obj.U1M1 }, func(obj *Struct) any { return obj.U1M2 })...)
+	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion2, func(obj *Struct) string { return string(obj.D2) }, func(obj *Struct) any { return obj.U2M1 }, func(obj *Struct) any { return obj.U2M2 })...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.D1 has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/simple/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/simple/zz_generated.validations.go
@@ -55,7 +55,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 		return nil // no changes
 	}
-	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, obj.D, obj.M1, obj.M2)...)
+	errs = append(errs, validate.DiscriminatedUnion[*Struct](ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) any { return obj.D }, func(obj *Struct) any { return obj.M1 }, func(obj *Struct) any { return obj.M2 })...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.D has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/simple/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/simple/zz_generated.validations.go
@@ -55,7 +55,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 		return nil // no changes
 	}
-	errs = append(errs, validate.DiscriminatedUnion[*Struct](ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) any { return obj.D }, func(obj *Struct) any { return obj.M1 }, func(obj *Struct) any { return obj.M2 })...)
+	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) any { return obj.D }, func(obj *Struct) any { return obj.M1 }, func(obj *Struct) any { return obj.M2 })...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.D has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/simple/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/simple/zz_generated.validations.go
@@ -55,7 +55,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 		return nil // no changes
 	}
-	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) any { return obj.D }, func(obj *Struct) any { return obj.M1 }, func(obj *Struct) any { return obj.M2 })...)
+	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) string { return string(obj.D) }, func(obj *Struct) any { return obj.M1 }, func(obj *Struct) any { return obj.M2 })...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.D has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/sparse/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/sparse/zz_generated.validations.go
@@ -55,7 +55,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 		return nil // no changes
 	}
-	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, obj.D, obj.M1)...)
+	errs = append(errs, validate.DiscriminatedUnion[*Struct](ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) any { return obj.D }, func(obj *Struct) any { return obj.M1 })...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.D has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/sparse/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/sparse/zz_generated.validations.go
@@ -55,7 +55,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 		return nil // no changes
 	}
-	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) any { return obj.D }, func(obj *Struct) any { return obj.M1 })...)
+	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) string { return string(obj.D) }, func(obj *Struct) any { return obj.M1 })...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.D has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/sparse/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/sparse/zz_generated.validations.go
@@ -55,7 +55,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 		return nil // no changes
 	}
-	errs = append(errs, validate.DiscriminatedUnion[*Struct](ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) any { return obj.D }, func(obj *Struct) any { return obj.M1 })...)
+	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) any { return obj.D }, func(obj *Struct) any { return obj.M1 })...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.D has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/custom_members/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/custom_members/doc_test.go
@@ -32,6 +32,6 @@ func Test(t *testing.T) {
 		field.Invalid(nil, "{m1, m2}", "must specify exactly one of: `m1`, `m2`"),
 	)
 	st.Value(&Struct{}).ExpectInvalid(
-		field.Invalid(nil, "", "must specify exactly one of: `m1`, `m2`"),
+		field.Invalid(nil, "", "must specify one of: `m1`, `m2`"),
 	)
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/custom_members/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/custom_members/zz_generated.validations.go
@@ -55,7 +55,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 		return nil // no changes
 	}
-	errs = append(errs, validate.Union[*Struct](ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) any { return obj.M1 }, func(obj *Struct) any { return obj.M2 })...)
+	errs = append(errs, validate.Union(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) any { return obj.M1 }, func(obj *Struct) any { return obj.M2 })...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.NonUnionField has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/custom_members/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/custom_members/zz_generated.validations.go
@@ -55,7 +55,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 		return nil // no changes
 	}
-	errs = append(errs, validate.Union(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, obj.M1, obj.M2)...)
+	errs = append(errs, validate.Union[*Struct](ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) any { return obj.M1 }, func(obj *Struct) any { return obj.M2 })...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.NonUnionField has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/multiple/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/multiple/doc_test.go
@@ -26,8 +26,8 @@ func Test(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
 	st.Value(&Struct{}).ExpectInvalid(
-		field.Invalid(nil, "", "must specify exactly one of: `u1m1`, `u1m2`"),
-		field.Invalid(nil, "", "must specify exactly one of: `u2m1`, `u2m2`"),
+		field.Invalid(nil, "", "must specify one of: `u1m1`, `u1m2`"),
+		field.Invalid(nil, "", "must specify one of: `u2m1`, `u2m2`"),
 	)
 
 	st.Value(&Struct{U1M1: &M1{}, U2M1: &M1{}}).ExpectValid()
@@ -35,11 +35,11 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{U1M1: &M1{}, U1M2: &M2{}}).ExpectInvalid(
 		field.Invalid(nil, "{u1m1, u1m2}", "must specify exactly one of: `u1m1`, `u1m2`"),
-		field.Invalid(nil, "", "must specify exactly one of: `u2m1`, `u2m2`"),
+		field.Invalid(nil, "", "must specify one of: `u2m1`, `u2m2`"),
 	)
 
 	st.Value(&Struct{U2M1: &M1{}, U2M2: &M2{}}).ExpectInvalid(
-		field.Invalid(nil, "", "must specify exactly one of: `u1m1`, `u1m2`"),
+		field.Invalid(nil, "", "must specify one of: `u1m1`, `u1m2`"),
 		field.Invalid(nil, "{u2m1, u2m2}", "must specify exactly one of: `u2m1`, `u2m2`"),
 	)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/multiple/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/multiple/zz_generated.validations.go
@@ -56,8 +56,8 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 		return nil // no changes
 	}
-	errs = append(errs, validate.Union[*Struct](ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion1, func(obj *Struct) any { return obj.U1M1 }, func(obj *Struct) any { return obj.U1M2 })...)
-	errs = append(errs, validate.Union[*Struct](ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion2, func(obj *Struct) any { return obj.U2M1 }, func(obj *Struct) any { return obj.U2M2 })...)
+	errs = append(errs, validate.Union(ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion1, func(obj *Struct) any { return obj.U1M1 }, func(obj *Struct) any { return obj.U1M2 })...)
+	errs = append(errs, validate.Union(ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion2, func(obj *Struct) any { return obj.U2M1 }, func(obj *Struct) any { return obj.U2M2 })...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.NonUnionField has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/multiple/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/multiple/zz_generated.validations.go
@@ -56,8 +56,8 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 		return nil // no changes
 	}
-	errs = append(errs, validate.Union(ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion1, obj.U1M1, obj.U1M2)...)
-	errs = append(errs, validate.Union(ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion2, obj.U2M1, obj.U2M2)...)
+	errs = append(errs, validate.Union[*Struct](ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion1, func(obj *Struct) any { return obj.U1M1 }, func(obj *Struct) any { return obj.U1M2 })...)
+	errs = append(errs, validate.Union[*Struct](ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion2, func(obj *Struct) any { return obj.U2M1 }, func(obj *Struct) any { return obj.U2M2 })...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.NonUnionField has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/simple/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/simple/doc_test.go
@@ -26,7 +26,7 @@ func Test(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
 	st.Value(&Struct{}).ExpectInvalid(
-		field.Invalid(nil, "", "must specify exactly one of: `m1`, `m2`"),
+		field.Invalid(nil, "", "must specify one of: `m1`, `m2`"),
 	)
 
 	st.Value(&Struct{M1: &M1{}}).ExpectValid()

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/simple/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/simple/zz_generated.validations.go
@@ -55,7 +55,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 		return nil // no changes
 	}
-	errs = append(errs, validate.Union[*Struct](ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) any { return obj.M1 }, func(obj *Struct) any { return obj.M2 })...)
+	errs = append(errs, validate.Union(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) any { return obj.M1 }, func(obj *Struct) any { return obj.M2 })...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.NonUnionField has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/simple/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/simple/zz_generated.validations.go
@@ -55,7 +55,7 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 		return nil // no changes
 	}
-	errs = append(errs, validate.Union(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, obj.M1, obj.M2)...)
+	errs = append(errs, validate.Union[*Struct](ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) any { return obj.M1 }, func(obj *Struct) any { return obj.M2 })...)
 
 	// field Struct.TypeMeta has no validation
 	// field Struct.NonUnionField has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
@@ -1320,6 +1320,8 @@ func toGolangSourceDataLiteral(sw *generator.SnippetWriter, c *generator.Context
 		sw.Do("$.|raw$", v)
 	case types.Member:
 		sw.Do("obj."+v.Name, nil)
+	case *types.Member:
+		sw.Do("obj."+v.Name, nil)
 	case validators.Identifier:
 		sw.Do("$.|raw$", c.Universe.Type(types.Name(v)))
 	case *validators.Identifier:

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/union.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/union.go
@@ -95,8 +95,8 @@ func (utv unionTypeValidator) GetValidations(context Context) (Validations, erro
 
 				discriminatorExtractor := FunctionLiteral{
 					Parameters: []ParamResult{{Name: "obj", Type: ptrType}},
-					Results:    []ParamResult{{Type: types.Any}},
-					Body:       fmt.Sprintf("return obj.%s", u.discriminatorMember.Name),
+					Results:    []ParamResult{{Type: types.String}},
+					Body:       fmt.Sprintf("return string(obj.%s)", u.discriminatorMember.Name), // Cast to string
 				}
 				extractorArgs = append(extractorArgs, discriminatorExtractor)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/union.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/union.go
@@ -83,10 +83,6 @@ func (utv unionTypeValidator) GetValidations(context Context) (Validations, erro
 			// TODO: Append a consistent hash suffix to avoid generated name conflicts?
 			supportVarName := PrivateVar{Name: "UnionMembershipFor" + context.Type.Name.Name + unionName, Package: "local"}
 			ptrType := types.PointerTo(context.Type)
-			ptrTypeName := types.Name{
-				Package: context.Type.Name.Package,
-				Name:    "*" + context.Type.Name.Name,
-			}
 
 			if u.discriminator != nil {
 				supportVar := Variable(supportVarName,
@@ -113,7 +109,7 @@ func (utv unionTypeValidator) GetValidations(context Context) (Validations, erro
 					extractorArgs = append(extractorArgs, extractor)
 				}
 
-				fn := Function(unionMemberTagName, DefaultFlags, discriminatedUnionValidator, extractorArgs...).WithTypeArgs(ptrTypeName)
+				fn := Function(unionMemberTagName, DefaultFlags, discriminatedUnionValidator, extractorArgs...)
 				result.Functions = append(result.Functions, fn)
 			} else {
 				supportVar := Variable(supportVarName, Function(unionMemberTagName, DefaultFlags, newUnionMembership, u.fields...))
@@ -131,7 +127,7 @@ func (utv unionTypeValidator) GetValidations(context Context) (Validations, erro
 					extractorArgs = append(extractorArgs, extractor)
 				}
 
-				fn := Function(unionMemberTagName, DefaultFlags, unionValidator, extractorArgs...).WithTypeArgs(ptrTypeName)
+				fn := Function(unionMemberTagName, DefaultFlags, unionValidator, extractorArgs...)
 				result.Functions = append(result.Functions, fn)
 			}
 		}


### PR DESCRIPTION
Part of: https://github.com/jpbetz/validation-gen/issues/90

This PR updates +k8s:unionMember and +k8s:unionDiscriminator to use extractor functions to get values of the for the fields and discriminators in the associated validate methods used in the generated code (Union and DiscriminatedUnion). This is a requirement for ratcheting so that values may be derived for obj and oldObj. 

Now generated code looks like:
```go
// Before: 
validate.Union(ctx, op, fldPath, obj, oldObj, unionMembership, obj.M1, obj.M2)
```
```go
// After:
validate.Union[*Struct](ctx, op, fldPath, obj, oldObj, unionMembership, 
    func(obj *Struct) any { return obj.M1 }, 
    func(obj *Struct) any { return obj.M2 })
```

All previous tests pass with the updated logic with no modifications.