### PR TITLE
Validate listmap typedefs the same as listmap fields

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/doc.go
@@ -39,6 +39,9 @@ type Struct struct {
 	// +k8s:eachVal=+k8s:immutable
 	ListTypedefField []OtherTypedefStruct `json:"listTypedefField"`
 
+	// +k8s:eachVal=+k8s:immutable
+	TypedefField ListType `json:"typedefField"`
+
 	// +k8s:listType=map
 	// +k8s:listMapKey=key1Field
 	// +k8s:listMapKey=key2Field
@@ -65,3 +68,8 @@ type NonComparableStruct struct {
 	Key2Field int      `json:"key2Field"`
 	DataField []string `json:"dataField"`
 }
+
+// +k8s:listType=map
+// +k8s:listMapKey=key1Field
+// +k8s:listMapKey=key2Field
+type ListType []OtherStruct

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/doc_test.go
@@ -34,6 +34,10 @@ func Test(t *testing.T) {
 			{"key1", 1, "one"},
 			{"key2", 2, "two"},
 		},
+		TypedefField: ListType{
+			{"key1", 1, "one"},
+			{"key2", 2, "two"},
+		},
 	}
 
 	// Same data, different order.
@@ -43,6 +47,10 @@ func Test(t *testing.T) {
 			{"key1", 1, "one"},
 		},
 		ListTypedefField: []OtherTypedefStruct{
+			{"key2", 2, "two"},
+			{"key1", 1, "one"},
+		},
+		TypedefField: ListType{
 			{"key2", 2, "two"},
 			{"key1", 1, "one"},
 		},
@@ -60,6 +68,11 @@ func Test(t *testing.T) {
 			{"key1", 1, "ONE"},
 			{"key2", 2, "TWO"},
 		},
+		TypedefField: ListType{
+			{"key3", 3, "THREE"},
+			{"key1", 1, "ONE"},
+			{"key2", 2, "TWO"},
+		},
 	}
 
 	st.Value(&structA1).OldValue(&structA2).ExpectValid()
@@ -71,6 +84,8 @@ func Test(t *testing.T) {
 		field.Forbidden(field.NewPath("listField").Index(1), "field is immutable"),
 		field.Forbidden(field.NewPath("listTypedefField").Index(0), "field is immutable"),
 		field.Forbidden(field.NewPath("listTypedefField").Index(1), "field is immutable"),
+		field.Forbidden(field.NewPath("typedefField").Index(0), "field is immutable"),
+		field.Forbidden(field.NewPath("typedefField").Index(1), "field is immutable"),
 	)
 
 	st.Value(&structB).OldValue(&structA1).ExpectInvalid(
@@ -80,6 +95,9 @@ func Test(t *testing.T) {
 		field.Forbidden(field.NewPath("listTypedefField").Index(0), "field is immutable"),
 		field.Forbidden(field.NewPath("listTypedefField").Index(1), "field is immutable"),
 		field.Forbidden(field.NewPath("listTypedefField").Index(2), "field is immutable"),
+		field.Forbidden(field.NewPath("typedefField").Index(0), "field is immutable"),
+		field.Forbidden(field.NewPath("typedefField").Index(1), "field is immutable"),
+		field.Forbidden(field.NewPath("typedefField").Index(2), "field is immutable"),
 	)
 
 	// Test validation ratcheting.
@@ -106,11 +124,11 @@ func Test(t *testing.T) {
 		},
 	}
 
-	st.Value(&structC2).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
-		field.Invalid(field.NewPath("listComparableField").Index(0), "", ""),
-		field.Invalid(field.NewPath("listComparableField").Index(1), "", ""),
-		field.Invalid(field.NewPath("listNonComparableField").Index(0), "", ""),
-		field.Invalid(field.NewPath("listNonComparableField").Index(1), "", ""),
+	st.Value(&structC2).ExpectValidateFalseByPath(map[string][]string{
+		"listComparableField[0]":    {"field Struct.ListComparableField[*]"},
+		"listComparableField[1]":    {"field Struct.ListComparableField[*]"},
+		"listNonComparableField[0]": {"field Struct.ListNonComparableField[*]"},
+		"listNonComparableField[1]": {"field Struct.ListNonComparableField[*]"},
 	})
 	st.Value(&structC).OldValue(&structC2).ExpectValid()
 }
@@ -127,9 +145,14 @@ func TestUniqueKey(t *testing.T) {
 			{"key1", 1, "one"},
 			{"key1", 1, "two"},
 		},
+		TypedefField: ListType{
+			{"key1", 1, "one"},
+			{"key1", 1, "two"},
+		},
 	}
-	st.Value(&structA).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin(), field.ErrorList{
+	st.Value(&structA).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.Duplicate(field.NewPath("listField[1]"), nil),
 		field.Duplicate(field.NewPath("listTypedefField[1]"), nil),
+		field.Duplicate(field.NewPath("typedefField[1]"), nil),
 	})
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/zz_generated.validations.go
@@ -48,6 +48,18 @@ func RegisterValidations(scheme *testscheme.Scheme) error {
 	return nil
 }
 
+func Validate_ListType(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj ListType) (errs field.ErrorList) {
+	// type ListType
+	if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+		return nil // no changes
+	}
+	errs = append(errs, validate.Unique(ctx, op, fldPath, obj, oldObj, func(a OtherStruct, b OtherStruct) bool {
+		return a.Key1Field == b.Key1Field && a.Key2Field == b.Key2Field
+	})...)
+
+	return errs
+}
+
 func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *Struct) (errs field.ErrorList) {
 	// field Struct.TypeMeta has no validation
 
@@ -80,6 +92,17 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			})...)
 			return
 		}(fldPath.Child("listTypedefField"), obj.ListTypedefField, safe.Field(oldObj, func(oldObj *Struct) []OtherTypedefStruct { return oldObj.ListTypedefField }))...)
+
+	// field Struct.TypedefField
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj ListType) (errs field.ErrorList) {
+			if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
+				return nil // no changes
+			}
+			errs = append(errs, validate.EachSliceVal(ctx, op, fldPath, obj, oldObj, validate.DirectEqual, nil, validate.ImmutableByCompare)...)
+			errs = append(errs, Validate_ListType(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("typedefField"), obj.TypedefField, safe.Field(oldObj, func(oldObj *Struct) ListType { return oldObj.TypedefField }))...)
 
 	// field Struct.ListComparableField
 	errs = append(errs,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/doc.go
@@ -37,6 +37,9 @@ type Struct struct {
 	// +k8s:eachVal=+k8s:immutable
 	ListTypedefField []OtherTypedefStruct `json:"listTypedefField"`
 
+	// +k8s:eachVal=+k8s:immutable
+	TypedefField ListType `json:"typedefField"`
+
 	// +k8s:listType=map
 	// +k8s:listMapKey=keyField
 	// +k8s:eachVal=+k8s:validateFalse="field Struct.ListComparableField[*]"
@@ -59,3 +62,7 @@ type NonComparableStruct struct {
 	KeyField       string  `json:"keyField"`
 	StringPtrField *string `json:"stringPtrField"`
 }
+
+// +k8s:listType=map
+// +k8s:listMapKey=keyField
+type ListType []OtherStruct

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/doc_test.go
@@ -35,6 +35,10 @@ func Test(t *testing.T) {
 			{"key1", "one"},
 			{"key2", "two"},
 		},
+		TypedefField: ListType{
+			{"key1", "one"},
+			{"key2", "two"},
+		},
 	}
 
 	// Same data, different order.
@@ -44,6 +48,10 @@ func Test(t *testing.T) {
 			{"key1", "one"},
 		},
 		ListTypedefField: []OtherTypedefStruct{
+			{"key2", "two"},
+			{"key1", "one"},
+		},
+		TypedefField: ListType{
 			{"key2", "two"},
 			{"key1", "one"},
 		},
@@ -61,6 +69,11 @@ func Test(t *testing.T) {
 			{"key1", "ONE"},
 			{"key2", "TWO"},
 		},
+		TypedefField: ListType{
+			{"key3", "THREE"},
+			{"key1", "ONE"},
+			{"key2", "TWO"},
+		},
 	}
 
 	st.Value(&structA1).OldValue(&structA2).ExpectValid()
@@ -72,6 +85,8 @@ func Test(t *testing.T) {
 		field.Forbidden(field.NewPath("listField").Index(1), "field is immutable"),
 		field.Forbidden(field.NewPath("listTypedefField").Index(0), "field is immutable"),
 		field.Forbidden(field.NewPath("listTypedefField").Index(1), "field is immutable"),
+		field.Forbidden(field.NewPath("typedefField").Index(0), "field is immutable"),
+		field.Forbidden(field.NewPath("typedefField").Index(1), "field is immutable"),
 	)
 
 	st.Value(&structB).OldValue(&structA1).ExpectInvalid(
@@ -81,6 +96,9 @@ func Test(t *testing.T) {
 		field.Forbidden(field.NewPath("listTypedefField").Index(0), "field is immutable"),
 		field.Forbidden(field.NewPath("listTypedefField").Index(1), "field is immutable"),
 		field.Forbidden(field.NewPath("listTypedefField").Index(2), "field is immutable"),
+		field.Forbidden(field.NewPath("typedefField").Index(0), "field is immutable"),
+		field.Forbidden(field.NewPath("typedefField").Index(1), "field is immutable"),
+		field.Forbidden(field.NewPath("typedefField").Index(2), "field is immutable"),
 	)
 
 	// Test validation ratcheting.
@@ -106,11 +124,11 @@ func Test(t *testing.T) {
 			{"key1", ptr.To("one")},
 		},
 	}
-	st.Value(&structC2).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
-		field.Invalid(field.NewPath("listComparableField").Index(0), "", ""),
-		field.Invalid(field.NewPath("listComparableField").Index(1), "", ""),
-		field.Invalid(field.NewPath("listNonComparableField").Index(0), "", ""),
-		field.Invalid(field.NewPath("listNonComparableField").Index(1), "", ""),
+	st.Value(&structC2).ExpectValidateFalseByPath(map[string][]string{
+		"listComparableField[0]":    {"field Struct.ListComparableField[*]"},
+		"listComparableField[1]":    {"field Struct.ListComparableField[*]"},
+		"listNonComparableField[0]": {"field Struct.ListNonComparableField[*]"},
+		"listNonComparableField[1]": {"field Struct.ListNonComparableField[*]"},
 	})
 	st.Value(&structC).OldValue(&structC2).ExpectValid()
 }
@@ -127,9 +145,14 @@ func TestUniqueKey(t *testing.T) {
 			{"key1", "one"},
 			{"key1", "two"},
 		},
+		TypedefField: ListType{
+			{"key1", "one"},
+			{"key1", "two"},
+		},
 	}
-	st.Value(&structA).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin(), field.ErrorList{
+	st.Value(&structA).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.Duplicate(field.NewPath("listField[1]"), nil),
 		field.Duplicate(field.NewPath("listTypedefField[1]"), nil),
+		field.Duplicate(field.NewPath("typedefField[1]"), nil),
 	})
 }


### PR DESCRIPTION
We currently allow a type to be defined as a listType=map, so we should apply the same validation we do for a field.