### PR TITLE
chore: Removed unnecessary type argument

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/enum/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/enum/zz_generated.validations.go
@@ -59,7 +59,7 @@ func Validate_Enum0(ctx context.Context, op operation.Operation, fldPath *field.
 	return errs
 }
 
-var symbolsForEnum1 = sets.New[Enum1](E1V1)
+var symbolsForEnum1 = sets.New(E1V1)
 
 // Validate_Enum1 validates an instance of Enum1 according
 // to declarative validation rules in the API schema.
@@ -69,7 +69,7 @@ func Validate_Enum1(ctx context.Context, op operation.Operation, fldPath *field.
 	return errs
 }
 
-var symbolsForEnum2 = sets.New[Enum2](E2V1, E2V2)
+var symbolsForEnum2 = sets.New(E2V1, E2V2)
 
 // Validate_Enum2 validates an instance of Enum2 according
 // to declarative validation rules in the API schema.

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/type_args/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/type_args/zz_generated.validations.go
@@ -70,7 +70,7 @@ func Validate_T1(ctx context.Context, op operation.Operation, fldPath *field.Pat
 				return nil
 			}
 			// call field-attached validations
-			errs = append(errs, validate.FixedResult[*primitives.T1](ctx, op, fldPath, obj, oldObj, false, "T1.S1")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T1.S1")...)
 			// call the type's validation function
 			errs = append(errs, primitives.Validate_T1(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -84,7 +84,7 @@ func Validate_T1(ctx context.Context, op operation.Operation, fldPath *field.Pat
 				return nil
 			}
 			// call field-attached validations
-			errs = append(errs, validate.FixedResult[*primitives.T1](ctx, op, fldPath, obj, oldObj, false, "PT1.PS1")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "PT1.PS1")...)
 			// call the type's validation function
 			errs = append(errs, primitives.Validate_T1(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -98,7 +98,7 @@ func Validate_T1(ctx context.Context, op operation.Operation, fldPath *field.Pat
 				return nil
 			}
 			// call field-attached validations
-			errs = append(errs, validate.FixedResult[*E1](ctx, op, fldPath, obj, oldObj, false, "T1.E1")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T1.E1")...)
 			// call the type's validation function
 			errs = append(errs, Validate_E1(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -112,7 +112,7 @@ func Validate_T1(ctx context.Context, op operation.Operation, fldPath *field.Pat
 				return nil
 			}
 			// call field-attached validations
-			errs = append(errs, validate.FixedResult[*E1](ctx, op, fldPath, obj, oldObj, true, "T1.PE1")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "T1.PE1")...)
 			// call the type's validation function
 			errs = append(errs, Validate_E1(ctx, op, fldPath, obj, oldObj)...)
 			return
@@ -126,7 +126,7 @@ func Validate_T1(ctx context.Context, op operation.Operation, fldPath *field.Pat
 				return nil
 			}
 			// call field-attached validations
-			errs = append(errs, validate.FixedResult[*int](ctx, op, fldPath, obj, oldObj, false, "T1.I1")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, false, "T1.I1")...)
 			return
 		}(fldPath.Child("i1"), &obj.I1, safe.Field(oldObj, func(oldObj *T1) *int { return &oldObj.I1 }))...)
 
@@ -138,7 +138,7 @@ func Validate_T1(ctx context.Context, op operation.Operation, fldPath *field.Pat
 				return nil
 			}
 			// call field-attached validations
-			errs = append(errs, validate.FixedResult[*int](ctx, op, fldPath, obj, oldObj, true, "T1.PI1")...)
+			errs = append(errs, validate.FixedResult(ctx, op, fldPath, obj, oldObj, true, "T1.PI1")...)
 			return
 		}(fldPath.Child("pi1"), obj.PI1, safe.Field(oldObj, func(oldObj *T1) *int { return oldObj.PI1 }))...)
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
@@ -1241,16 +1241,6 @@ func emitCallsToValidators(c *generator.Context, validations []validators.Functi
 
 			emitCall := func() {
 				sw.Do("$.funcName|raw$", targs)
-				if typeArgs := v.TypeArgs; len(typeArgs) > 0 {
-					sw.Do("[", nil)
-					for i, typeArg := range typeArgs {
-						sw.Do("$.|raw$", c.Universe.Type(typeArg))
-						if i < len(typeArgs)-1 {
-							sw.Do(",", nil)
-						}
-					}
-					sw.Do("]", nil)
-				}
 				sw.Do("(ctx, op, fldPath, obj, oldObj", targs)
 				for _, arg := range v.Args {
 					sw.Do(", ", nil)
@@ -1397,7 +1387,7 @@ func (g *genValidations) emitValidationVariables(c *generator.Context, t *types.
 				sw.Do("// $.$\n", comment)
 			}
 			sw.Do("var $.varName|private$ = $.initFn|raw$", targs)
-			if typeArgs := fn.TypeArgs; len(typeArgs) > 0 {
+			if typeArgs := fn.TypeArgs; len(typeArgs) > 0 && len(fn.Args) == 0 {
 				sw.Do("[", nil)
 				for i, typeArg := range typeArgs {
 					sw.Do("$.|raw$", c.Universe.Type(typeArg))
@@ -1483,17 +1473,6 @@ func toGolangSourceDataLiteral(sw *generator.SnippetWriter, c *generator.Context
 
 			emitCall := func() {
 				sw.Do("return $.funcName|raw$", targs)
-				typeArgs := v.Function.TypeArgs
-				if len(typeArgs) > 0 {
-					sw.Do("[", nil)
-					for i, typeArg := range typeArgs {
-						sw.Do("$.|raw$", c.Universe.Type(typeArg))
-						if i < len(typeArgs)-1 {
-							sw.Do(",", nil)
-						}
-					}
-					sw.Do("]", nil)
-				}
 				sw.Do("(ctx, op, fldPath, obj, oldObj", targs)
 				for _, arg := range extraArgs {
 					sw.Do(", ", nil)


### PR DESCRIPTION
- Remove unnecessary type assertion when they can be inferred.
  - For VariableGen, only requires when initialization func has empty args
  - For FunctionGen, it would always pass in an "obj" with type asserted.