### PR TITLE
Change union ratcheting to only look at membership

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/custom_members/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/custom_members/zz_generated.validations.go
@@ -56,20 +56,20 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 		return nil // no changes
 	}
 	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) string {
-		if obj != nil {
-			return string(obj.D)
+		if obj == nil {
+			return ""
 		}
-		return ""
-	}, func(obj *Struct) any {
-		if obj != nil {
-			return obj.M1
+		return string(obj.D)
+	}, func(obj *Struct) bool {
+		if obj == nil {
+			return false
 		}
-		return nil
-	}, func(obj *Struct) any {
-		if obj != nil {
-			return obj.M2
+		return obj.M1 != nil
+	}, func(obj *Struct) bool {
+		if obj == nil {
+			return false
 		}
-		return nil
+		return obj.M2 != nil
 	})...)
 
 	// field Struct.TypeMeta has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/empty/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/empty/zz_generated.validations.go
@@ -55,10 +55,10 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 		return nil // no changes
 	}
 	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) string {
-		if obj != nil {
-			return string(obj.D)
+		if obj == nil {
+			return ""
 		}
-		return ""
+		return string(obj.D)
 	})...)
 
 	// field Struct.TypeMeta has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/multiple/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/multiple/zz_generated.validations.go
@@ -57,36 +57,36 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 		return nil // no changes
 	}
 	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion1, func(obj *Struct) string {
-		if obj != nil {
-			return string(obj.D1)
+		if obj == nil {
+			return ""
 		}
-		return ""
-	}, func(obj *Struct) any {
-		if obj != nil {
-			return obj.U1M1
+		return string(obj.D1)
+	}, func(obj *Struct) bool {
+		if obj == nil {
+			return false
 		}
-		return nil
-	}, func(obj *Struct) any {
-		if obj != nil {
-			return obj.U1M2
+		return obj.U1M1 != nil
+	}, func(obj *Struct) bool {
+		if obj == nil {
+			return false
 		}
-		return nil
+		return obj.U1M2 != nil
 	})...)
 	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion2, func(obj *Struct) string {
-		if obj != nil {
-			return string(obj.D2)
+		if obj == nil {
+			return ""
 		}
-		return ""
-	}, func(obj *Struct) any {
-		if obj != nil {
-			return obj.U2M1
+		return string(obj.D2)
+	}, func(obj *Struct) bool {
+		if obj == nil {
+			return false
 		}
-		return nil
-	}, func(obj *Struct) any {
-		if obj != nil {
-			return obj.U2M2
+		return obj.U2M1 != nil
+	}, func(obj *Struct) bool {
+		if obj == nil {
+			return false
 		}
-		return nil
+		return obj.U2M2 != nil
 	})...)
 
 	// field Struct.TypeMeta has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/simple/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/simple/zz_generated.validations.go
@@ -56,20 +56,20 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 		return nil // no changes
 	}
 	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) string {
-		if obj != nil {
-			return string(obj.D)
+		if obj == nil {
+			return ""
 		}
-		return ""
-	}, func(obj *Struct) any {
-		if obj != nil {
-			return obj.M1
+		return string(obj.D)
+	}, func(obj *Struct) bool {
+		if obj == nil {
+			return false
 		}
-		return nil
-	}, func(obj *Struct) any {
-		if obj != nil {
-			return obj.M2
+		return obj.M1 != nil
+	}, func(obj *Struct) bool {
+		if obj == nil {
+			return false
 		}
-		return nil
+		return obj.M2 != nil
 	})...)
 
 	// field Struct.TypeMeta has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/sparse/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/sparse/zz_generated.validations.go
@@ -56,15 +56,15 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 		return nil // no changes
 	}
 	errs = append(errs, validate.DiscriminatedUnion(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) string {
-		if obj != nil {
-			return string(obj.D)
+		if obj == nil {
+			return ""
 		}
-		return ""
-	}, func(obj *Struct) any {
-		if obj != nil {
-			return obj.M1
+		return string(obj.D)
+	}, func(obj *Struct) bool {
+		if obj == nil {
+			return false
 		}
-		return nil
+		return obj.M1 != nil
 	})...)
 
 	// field Struct.TypeMeta has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/custom_members/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/custom_members/zz_generated.validations.go
@@ -55,16 +55,16 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 		return nil // no changes
 	}
-	errs = append(errs, validate.Union(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) any {
-		if obj != nil {
-			return obj.M1
+	errs = append(errs, validate.Union(ctx, op, fldPath, obj, oldObj, unionMembershipForStruct, func(obj *Struct) bool {
+		if obj == nil {
+			return false
 		}
-		return nil
-	}, func(obj *Struct) any {
-		if obj != nil {
-			return obj.M2
+		return obj.M1 != nil
+	}, func(obj *Struct) bool {
+		if obj == nil {
+			return false
 		}
-		return nil
+		return obj.M2 != nil
 	})...)
 
 	// field Struct.TypeMeta has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/multiple/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/multiple/zz_generated.validations.go
@@ -56,27 +56,27 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	if op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 		return nil // no changes
 	}
-	errs = append(errs, validate.Union(ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion1, func(obj *Struct) any {
-		if obj != nil {
-			return obj.U1M1
+	errs = append(errs, validate.Union(ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion1, func(obj *Struct) bool {
+		if obj == nil {
+			return false
 		}
-		return nil
-	}, func(obj *Struct) any {
-		if obj != nil {
-			return obj.U1M2
+		return obj.U1M1 != nil
+	}, func(obj *Struct) bool {
+		if obj == nil {
+			return false
 		}
-		return nil
+		return obj.U1M2 != nil
 	})...)
-	errs = append(errs, validate.Union(ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion2, func(obj *Struct) any {
-		if obj != nil {
-			return obj.U2M1
+	errs = append(errs, validate.Union(ctx, op, fldPath, obj, oldObj, unionMembershipForStructunion2, func(obj *Struct) bool {
+		if obj == nil {
+			return false
 		}
-		return nil
-	}, func(obj *Struct) any {
-		if obj != nil {
-			return obj.U2M2
+		return obj.U2M1 != nil
+	}, func(obj *Struct) bool {
+		if obj == nil {
+			return false
 		}
-		return nil
+		return obj.U2M2 != nil
 	})...)
 
 	// field Struct.TypeMeta has no validation

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/simple/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/simple/doc.go
@@ -37,6 +37,14 @@ type Struct struct {
 	// +k8s:unionMember
 	// +k8s:optional
 	M2 *M2 `json:"m2"`
+
+	// +k8s:unionMember
+	// +k8s:optional
+	M3 string `json:"m3"`
+
+	// +k8s:unionMember
+	// +k8s:optional
+	M4 *string `json:"m4"`
 }
 
 type M1 struct{}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/simple/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/simple/doc_test.go
@@ -20,23 +20,36 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
 	st.Value(&Struct{}).ExpectInvalid(
-		field.Invalid(nil, "", "must specify one of: `m1`, `m2`"),
+		field.Invalid(nil, "", "must specify one of: `m1`, `m2`, `m3`, `m4`"),
 	)
 
 	st.Value(&Struct{M1: &M1{}}).ExpectValid()
 	st.Value(&Struct{M2: &M2{}}).ExpectValid()
+	st.Value(&Struct{M3: "a string"}).ExpectValid()
+	st.Value(&Struct{M4: ptr.To("a string")}).ExpectValid()
 
 	st.Value(&Struct{M1: &M1{}, M2: &M2{}}).ExpectInvalid(
-		field.Invalid(nil, "{m1, m2}", "must specify exactly one of: `m1`, `m2`"),
+		field.Invalid(nil, "{m1, m2}", "must specify exactly one of: `m1`, `m2`, `m3`, `m4`"),
+	)
+	st.Value(&Struct{M1: &M1{}, M3: "a string"}).ExpectInvalid(
+		field.Invalid(nil, "{m1, m3}", "must specify exactly one of: `m1`, `m2`, `m3`, `m4`"),
+	)
+	st.Value(&Struct{M1: &M1{}, M4: ptr.To("a string")}).ExpectInvalid(
+		field.Invalid(nil, "{m1, m4}", "must specify exactly one of: `m1`, `m2`, `m3`, `m4`"),
 	)
 
+	// Update only considers whether a field was set, not the value.
+	st.Value(&Struct{M3: "a string"}).OldValue(&Struct{M3: "different string"}).ExpectValid()
+
 	// Test validation ratcheting
-	st.Value(&Struct{M1: &M1{}, M2: &M2{}}).OldValue(&Struct{M1: &M1{}, M2: &M2{}}).ExpectValid()
 	st.Value(&Struct{}).OldValue(&Struct{}).ExpectValid()
+	st.Value(&Struct{M1: &M1{}, M2: &M2{}}).OldValue(&Struct{M1: &M1{}, M2: &M2{}}).ExpectValid()
+	st.Value(&Struct{M3: "a string", M2: &M2{}}).OldValue(&Struct{M3: "different string", M2: &M2{}}).ExpectValid()
 }


### PR DESCRIPTION
We don't care if the values of the members changed, only which members are set / unset.

