### PR TITLE
chore: fix forward on validation versioned test

### DIFF
--- a/pkg/api/testing/validation.go
+++ b/pkg/api/testing/validation.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	runtimetest "k8s.io/apimachinery/pkg/runtime/testing"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -37,10 +38,28 @@ func VerifyVersionedValidationEquivalence(t *testing.T, obj, old k8sruntime.Obje
 	accumulate := func(t *testing.T, gv string, errs field.ErrorList) {
 		all[gv] = errs
 	}
+	// Convert versioned object to internal format before validation.
+	// runtimetest.RunValidationForEachVersion requires unversioned (internal) objects as input.
+	internalObj, err := convertToInternal(t, legacyscheme.Scheme, obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if internalObj == nil {
+		return
+	}
 	if old == nil {
-		runtimetest.RunValidationForEachVersion(t, legacyscheme.Scheme, []string{}, obj, accumulate)
+		runtimetest.RunValidationForEachVersion(t, legacyscheme.Scheme, []string{}, internalObj, accumulate, subresources...)
 	} else {
-		runtimetest.RunUpdateValidationForEachVersion(t, legacyscheme.Scheme, []string{}, obj, old, accumulate)
+		// Convert old versioned object to internal format before validation.
+		// runtimetest.RunUpdateValidationForEachVersion requires unversioned (internal) objects as input.
+		internalOld, err := convertToInternal(t, legacyscheme.Scheme, old)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if internalOld == nil {
+			return
+		}
+		runtimetest.RunUpdateValidationForEachVersion(t, legacyscheme.Scheme, []string{}, internalObj, internalOld, accumulate, subresources...)
 	}
 
 	// Make a copy so we can modify it.
@@ -103,4 +122,26 @@ func fmtErrs(errs field.ErrorList) string {
 	}
 
 	return buf.String()
+}
+
+func convertToInternal(t *testing.T, scheme *k8sruntime.Scheme, obj k8sruntime.Object) (k8sruntime.Object, error) {
+	t.Helper()
+
+	gvks, _, err := scheme.ObjectKinds(obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gvks) == 0 {
+		t.Fatal("no GVKs found for object")
+	}
+	gvk := gvks[0]
+	if gvk.Version == k8sruntime.APIVersionInternal {
+		return obj, nil
+	}
+	gvk.Version = k8sruntime.APIVersionInternal
+	if !scheme.Recognizes(gvk) {
+		t.Logf("no internal object found for GroupKind %s", gvk.GroupKind().String())
+		return nil, nil
+	}
+	return scheme.ConvertToVersion(obj, schema.GroupVersion{Group: gvk.Group, Version: k8sruntime.APIVersionInternal})
 }

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/testing/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/testing/validation.go
@@ -52,14 +52,13 @@ func runValidation(t *testing.T, scheme *runtime.Scheme, options []string, unver
 		t.Fatal(err)
 	}
 	for _, unversionedGVK := range unversionedGVKs {
+		// skip if passed in unversioned object is not internal.
+		if unversionedGVK.Version != runtime.APIVersionInternal {
+			continue
+		}
 		gvs := scheme.VersionsForGroupKind(unversionedGVK.GroupKind())
 		for _, gv := range gvs {
 			gvk := gv.WithKind(unversionedGVK.Kind)
-			// skip if the version is not the same as the unversioned object.
-			// We should not convert between different versions of the same object.
-			if gvk.Version != unversionedGVK.Version {
-				continue
-			}
 			t.Run(gvk.String(), func(t *testing.T) {
 				if gvk.Version != runtime.APIVersionInternal { // skip internal
 					versioned, err := scheme.New(gvk)
@@ -83,14 +82,13 @@ func runUpdateValidation(t *testing.T, scheme *runtime.Scheme, options []string,
 		t.Fatal(err)
 	}
 	for _, unversionedGVK := range unversionedGVKs {
+		// skip if passed in unversioned object is not internal.
+		if unversionedGVK.Version != runtime.APIVersionInternal {
+			continue
+		}
 		gvs := scheme.VersionsForGroupKind(unversionedGVK.GroupKind())
 		for _, gv := range gvs {
 			gvk := gv.WithKind(unversionedGVK.Kind)
-			// skip if the version is not the same as the unversioned object.
-			// We should not convert between different versions of the same object.
-			if gvk.Version != unversionedGVK.Version {
-				continue
-			}
 			t.Run(gvk.String(), func(t *testing.T) {
 				if gvk.Version != runtime.APIVersionInternal { // skip internal
 					versionedNew, err := scheme.New(gvk)


### PR DESCRIPTION
Keep consistent with https://github.com/kubernetes/kubernetes/pull/132465
This would pave the road for the following migration of CSR.