### PR TITLE
refactor(validation): Rename k8s-ip-sloppy format to k8s-ip

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -7621,7 +7621,7 @@ func ValidateEndpointIP(ipAddress string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	ip := netutils.ParseIPSloppy(ipAddress)
 	if ip == nil {
-		allErrs = append(allErrs, field.Invalid(fldPath, ipAddress, "must be a valid IP address").WithOrigin("format=k8s-ip-sloppy"))
+		allErrs = append(allErrs, field.Invalid(fldPath, ipAddress, "must be a valid IP address").WithOrigin("format=k8s-ip"))
 		return allErrs
 	}
 	if ip.IsUnspecified() {

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -21429,7 +21429,7 @@ func TestValidateEndpointsCreate(t *testing.T) {
 				}},
 			},
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("subsets[0].addresses[0].ip"), nil, "").WithOrigin("format=k8s-ip-sloppy"),
+				field.Invalid(field.NewPath("subsets[0].addresses[0].ip"), nil, "").WithOrigin("format=k8s-ip"),
 			},
 		},
 		"invalid legacy IP with strict validation": {
@@ -21441,7 +21441,7 @@ func TestValidateEndpointsCreate(t *testing.T) {
 				}},
 			},
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("subsets[0].addresses[0].ip"), nil, "").WithOrigin("format=k8s-ip-sloppy"),
+				field.Invalid(field.NewPath("subsets[0].addresses[0].ip"), nil, "").WithOrigin("format=k8s-ip"),
 			},
 		},
 		"Multiple ports, one without name": {
@@ -21489,7 +21489,7 @@ func TestValidateEndpointsCreate(t *testing.T) {
 				}},
 			},
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("subsets[0].addresses[0].ip"), nil, "").WithOrigin("format=k8s-ip-sloppy"),
+				field.Invalid(field.NewPath("subsets[0].addresses[0].ip"), nil, "").WithOrigin("format=k8s-ip"),
 			},
 		},
 		"Port missing number": {

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/net.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/net.go
@@ -41,7 +41,7 @@ func ipSloppy(ctx context.Context, op operation.Operation, fldPath *field.Path, 
 	ip := netutils.ParseIPSloppy(*value)
 	if ip == nil {
 		return nil, field.ErrorList{
-			field.Invalid(fldPath, *value, "must be a valid IP address (e.g. 10.9.8.7 or 2001:db8::ffff)").WithOrigin("format=k8s-ip-sloppy"),
+			field.Invalid(fldPath, *value, "must be a valid IP address (e.g. 10.9.8.7 or 2001:db8::ffff)").WithOrigin("format=k8s-ip"),
 		}
 	}
 	return ip, nil

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/ip.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/ip.go
@@ -83,7 +83,7 @@ func IsValidIPForLegacyField(fldPath *field.Path, value string, strictValidation
 		return nil
 	}
 	_, allErrors := parseIP(fldPath, value, strictValidation)
-	return allErrors.WithOrigin("format=k8s-ip-sloppy")
+	return allErrors.WithOrigin("format=k8s-ip")
 }
 
 // IsValidIP tests that the argument is a valid IP address, according to current

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/doc.go
@@ -27,10 +27,10 @@ var localSchemeBuilder = testscheme.New()
 type Struct struct {
 	TypeMeta int
 
-	// +k8s:format=k8s-ip-sloppy
+	// +k8s:format=k8s-ip
 	IPField string `json:"ipField"`
 
-	// +k8s:format=k8s-ip-sloppy
+	// +k8s:format=k8s-ip
 	IPPtrField *string `json:"ipPtrField"`
 
 	// Note: no validation here
@@ -46,7 +46,7 @@ type Struct struct {
 	ShortNameTypedefField ShortNameStringType `json:"shortNameTypedefField"`
 }
 
-// +k8s:format=k8s-ip-sloppy
+// +k8s:format=k8s-ip
 type IPStringType string
 
 // +k8s:format=k8s-short-name

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/doc_test.go
@@ -53,9 +53,9 @@ func Test(t *testing.T) {
 		ShortNameTypedefField: "",
 	}
 	st.Value(invalidStruct).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin(), field.ErrorList{
-		field.Invalid(field.NewPath("ipField"), nil, "").WithOrigin("format=k8s-ip-sloppy"),
-		field.Invalid(field.NewPath("ipPtrField"), nil, "").WithOrigin("format=k8s-ip-sloppy"),
-		field.Invalid(field.NewPath("ipTypedefField"), nil, "").WithOrigin("format=k8s-ip-sloppy"),
+		field.Invalid(field.NewPath("ipField"), nil, "").WithOrigin("format=k8s-ip"),
+		field.Invalid(field.NewPath("ipPtrField"), nil, "").WithOrigin("format=k8s-ip"),
+		field.Invalid(field.NewPath("ipTypedefField"), nil, "").WithOrigin("format=k8s-ip"),
 		field.Invalid(field.NewPath("shortNameField"), nil, "").WithOrigin("format=k8s-short-name"),
 		field.Invalid(field.NewPath("shortNamePtrField"), nil, "").WithOrigin("format=k8s-short-name"),
 		field.Invalid(field.NewPath("shortNameTypedefField"), nil, "").WithOrigin("format=k8s-short-name"),
@@ -72,9 +72,9 @@ func Test(t *testing.T) {
 		ShortNameTypedefField: "Not a ShortName",
 	}
 	st.Value(invalidStruct).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin(), field.ErrorList{
-		field.Invalid(field.NewPath("ipField"), nil, "").WithOrigin("format=k8s-ip-sloppy"),
-		field.Invalid(field.NewPath("ipPtrField"), nil, "").WithOrigin("format=k8s-ip-sloppy"),
-		field.Invalid(field.NewPath("ipTypedefField"), nil, "").WithOrigin("format=k8s-ip-sloppy"),
+		field.Invalid(field.NewPath("ipField"), nil, "").WithOrigin("format=k8s-ip"),
+		field.Invalid(field.NewPath("ipPtrField"), nil, "").WithOrigin("format=k8s-ip"),
+		field.Invalid(field.NewPath("ipTypedefField"), nil, "").WithOrigin("format=k8s-ip"),
 		field.Invalid(field.NewPath("shortNameField"), nil, "").WithOrigin("format=k8s-short-name"),
 		field.Invalid(field.NewPath("shortNamePtrField"), nil, "").WithOrigin("format=k8s-short-name"),
 		field.Invalid(field.NewPath("shortNameTypedefField"), nil, "").WithOrigin("format=k8s-short-name"),

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/format.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/format.go
@@ -73,7 +73,7 @@ func getFormatValidationFunction(format string) (FunctionGen, error) {
 	// all lower-case, dashes between words. See
 	// https://json-schema.org/draft/2020-12/json-schema-validation#name-defined-formats
 	// for more examples.
-	if format == "k8s-ip-sloppy" {
+	if format == "k8s-ip" {
 		return Function(formatTagName, DefaultFlags, ipSloppyValidator), nil
 	}
 	if format == "k8s-short-name" {
@@ -90,7 +90,7 @@ func (ftv formatTagValidator) Docs() TagDoc {
 		Scopes:      ftv.ValidScopes().UnsortedList(),
 		Description: "Indicates that a string field has a particular format.",
 		Payloads: []TagPayloadDoc{{
-			Description: "k8s-ip-sloppy",
+			Description: "k8s-ip",
 			Docs:        "This field holds an IPv4 or IPv6 address value. IPv4 octets may have leading zeros.",
 		}, {
 			Description: "k8s-short-name",


### PR DESCRIPTION
The custom IP address validation format used within Kubernetes was previously named 'k8s-ip-sloppy'. This name was chosen as a temporary placeholder to reserve the 'k8s-ip' format name for a future, stricter IP validation implementation.

With the introduction of validation ratcheting, it is now possible to evolve validation rules for fields without breaking existing stored objects. This makes the "sloppy" suffix redundant, as the validation for 'k8s-ip' can be tightened over time as needed.
