### PR TITLE
Fix validation-gen panic on unknown tags during code generation

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/registry.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/registry.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -147,11 +148,27 @@ func (reg *registry) ExtractValidations(context Context, tags ...codetags.Tag) (
 	}
 	validations := Validations{}
 
+	// Check all tags first for tag processing issues
+	var errors []string
+	for _, tag := range tags {
+		if tv, exists := reg.tagValidators[tag.Name]; !exists {
+			errors = append(errors, fmt.Sprintf("unknown tag %q", tag.Name))
+		} else if tv == nil {
+			errors = append(errors, fmt.Sprintf("nil validator for tag %q", tag.Name))
+		}
+	}
+
+	// If there are tag processing issues, report them all together
+	if len(errors) > 0 {
+		return Validations{}, fmt.Errorf("tag processing errors: %s", strings.Join(errors, "; "))
+	}
+
 	// Run tag-validators first.
 	phases := reg.sortTagsIntoPhases(tags)
 	for _, tags := range phases {
 		for _, tag := range tags {
 			tv := reg.tagValidators[tag.Name]
+			// At this point we know tv exists and is not nil due to the upfront check
 			if scopes := tv.ValidScopes(); !scopes.Has(context.Scope) && !scopes.Has(ScopeAny) {
 				return Validations{}, fmt.Errorf("tag %q cannot be specified on %s", tv.TagName(), context.Scope)
 			}
@@ -228,6 +245,8 @@ func (reg *registry) sortTagsIntoPhases(tags []codetags.Tag) [][]codetags.Tag {
 	phase1 := []codetags.Tag{} // "late" tags
 	for _, tn := range sortedTags {
 		tv := reg.tagValidators[tn.Name]
+		// Note: We don't filter out unknown tags here since ExtractValidations
+		// handles all tag processing logic upfront.
 		if _, ok := tv.(LateTagValidator); ok {
 			phase1 = append(phase1, tn)
 		} else {
@@ -241,7 +260,12 @@ func (reg *registry) sortTagsIntoPhases(tags []codetags.Tag) [][]codetags.Tag {
 func (reg *registry) Docs() []TagDoc {
 	var result []TagDoc
 	for _, k := range reg.tagIndex {
-		v := reg.tagValidators[k]
+		v, exists := reg.tagValidators[k]
+		if !exists {
+			// Skip unknown tags - this shouldn't happen in normal operation
+			// but provides safety against data corruption
+			continue
+		}
 		result = append(result, v.Docs())
 	}
 	return result

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/registry_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/registry_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validators
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/gengo/v2/codetags"
+	"k8s.io/gengo/v2/types"
+)
+
+func TestExtractValidations_TagValidator(t *testing.T) {
+	tests := []struct {
+		name    string
+		tags    []codetags.Tag
+		setup   func(*registry)
+		wantErr string
+	}{
+		{
+			name: "known tag",
+			tags: []codetags.Tag{{Name: "known:tag"}},
+			setup: func(r *registry) {
+				r.tagValidators["known:tag"] = &mockTagValidator{tagName: "known:tag", scopes: sets.New(ScopeType)}
+			},
+			wantErr: "",
+		},
+		{
+			name:    "unknown tag",
+			tags:    []codetags.Tag{{Name: "unknown:tag"}},
+			setup:   func(r *registry) {},
+			wantErr: "tag processing errors: unknown tag \"unknown:tag\"",
+		},
+		{
+			name:    "nil validator",
+			tags:    []codetags.Tag{{Name: "nil:tag"}},
+			setup:   func(r *registry) { r.tagValidators["nil:tag"] = nil },
+			wantErr: "tag processing errors: nil validator for tag \"nil:tag\"",
+		},
+		{
+			name: "multiple errors",
+			tags: []codetags.Tag{
+				{Name: "valid:tag1"}, {Name: "valid:tag2"},
+				{Name: "nil:tag1"}, {Name: "nil:tag2"},
+				{Name: "unknown:tag1"}, {Name: "unknown:tag2"}, {Name: "unknown:tag3"},
+			},
+			setup: func(r *registry) {
+				r.tagValidators["valid:tag1"] = &mockTagValidator{tagName: "valid:tag1", scopes: sets.New(ScopeType)}
+				r.tagValidators["valid:tag2"] = &mockTagValidator{tagName: "valid:tag2", scopes: sets.New(ScopeType)}
+				r.tagValidators["nil:tag1"], r.tagValidators["nil:tag2"] = nil, nil
+			},
+			wantErr: "tag processing errors: nil validator for tag \"nil:tag1\"; nil validator for tag \"nil:tag2\"; unknown tag \"unknown:tag1\"; unknown tag \"unknown:tag2\"; unknown tag \"unknown:tag3\"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &registry{tagValidators: map[string]TagValidator{}, initialized: atomic.Bool{}}
+			r.initialized.Store(true)
+			tt.setup(r)
+
+			_, err := r.ExtractValidations(Context{Scope: ScopeType}, tt.tags...)
+
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("Expected no error, got %v", err)
+				}
+			} else if err == nil {
+				t.Fatal("Expected error, got nil")
+			} else if err.Error() != tt.wantErr {
+				t.Errorf("Expected error %q, got %q", tt.wantErr, err.Error())
+			}
+		})
+	}
+}
+
+// Mock implementations for testing
+type mockTagValidator struct {
+	tagName string
+	scopes  sets.Set[Scope]
+}
+
+func (m *mockTagValidator) Init(cfg Config) {}
+func (m *mockTagValidator) TagName() string { return m.tagName }
+func (m *mockTagValidator) ValidScopes() sets.Set[Scope] {
+	if m.scopes == nil {
+		return sets.New(ScopeAny)
+	}
+	return m.scopes
+}
+func (m *mockTagValidator) GetValidations(context Context, tag codetags.Tag) (Validations, error) {
+	result := Validations{}
+	// Create a simple validation function
+	fn := Function(m.tagName, DefaultFlags, types.Name{Package: "test", Name: "MockValidator"})
+	result.AddFunction(fn)
+	return result, nil
+}
+func (m *mockTagValidator) Docs() TagDoc {
+	return TagDoc{Tag: m.tagName}
+}


### PR DESCRIPTION
Fix: #153 

I originally added the nil check to for-loop in ExtractValidations here
```go
// Run tag-validators first.
phases := reg.sortTagsIntoPhases(tags)
for _, tags := range phases {
		for _, tag := range tags {
			tv := reg.tagValidators[tag.Name]
-------> // nil check here
```
when I found out that we should check the tags in `sortTagsIntoPhases`. Then I finally moved all the checks upfront and aggregated any "not found" errors.