### PR TITLE
feat(validation): Add origin to validation errors

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -6798,7 +6798,7 @@ func ValidateReplicationControllerSpec(spec, oldSpec *core.ReplicationController
 	allErrs = append(allErrs, ValidateNonnegativeField(int64(spec.MinReadySeconds), fldPath.Child("minReadySeconds")).MarkCoveredByDeclarative()...)
 	allErrs = append(allErrs, ValidateNonEmptySelector(spec.Selector, fldPath.Child("selector"))...)
 	if spec.Replicas == nil {
-		allErrs = append(allErrs, field.Required(fldPath.Child("replicas"), "").MarkCoveredByDeclarative())
+		allErrs = append(allErrs, field.Required(fldPath.Child("replicas"), "").WithOrigin("required").MarkCoveredByDeclarative())
 	} else {
 		allErrs = append(allErrs, ValidateNonnegativeField(int64(*spec.Replicas), fldPath.Child("replicas")).MarkCoveredByDeclarative()...)
 	}

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -17979,7 +17979,7 @@ func TestValidateReplicationControllerUpdate(t *testing.T) {
 				rc.Spec.Replicas = nil
 			}),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec.replicas"), ""),
+				field.Required(field.NewPath("spec.replicas"), "").WithOrigin("required"),
 			},
 		},
 		"negative minReadySeconds": {
@@ -18091,7 +18091,7 @@ func TestValidateReplicationController(t *testing.T) {
 		"nil replicas": {
 			input: mkValidReplicationController(func(rc *core.ReplicationController) { rc.Spec.Replicas = nil }),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec.replicas"), ""),
+				field.Required(field.NewPath("spec.replicas"), "").WithOrigin("required"),
 			},
 		},
 		"invalid label": {

--- a/pkg/registry/core/replicationcontroller/declarative_validation_test.go
+++ b/pkg/registry/core/replicationcontroller/declarative_validation_test.go
@@ -161,7 +161,7 @@ func TestDeclarativeValidation(t *testing.T) {
 				rc.Spec.Replicas = nil
 			}),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec.replicas"), ""),
+				field.Required(field.NewPath("spec.replicas"), "").WithOrigin("required"),
 			},
 		},
 		"replicas: 0": {
@@ -268,7 +268,7 @@ func TestUpdateDeclarativeValidation(t *testing.T) {
 				rc.Spec.Replicas = nil
 			}),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec.replicas"), ""),
+				field.Required(field.NewPath("spec.replicas"), "").WithOrigin("required"),
 			},
 		},
 		"replicas: 0": {

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/immutable.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/immutable.go
@@ -41,7 +41,7 @@ func ImmutableByCompare[T comparable](_ context.Context, op operation.Operation,
 	}
 	if value == nil || oldValue == nil || *value != *oldValue {
 		return field.ErrorList{
-			field.Forbidden(fldPath, "field is immutable"),
+			field.Forbidden(fldPath, "field is immutable").WithOrigin("immutable"),
 		}
 	}
 	return nil
@@ -57,7 +57,7 @@ func ImmutableByReflect[T any](_ context.Context, op operation.Operation, fldPat
 	}
 	if !equality.Semantic.DeepEqual(value, oldValue) {
 		return field.ErrorList{
-			field.Forbidden(fldPath, "field is immutable"),
+			field.Forbidden(fldPath, "field is immutable").WithOrigin("immutable"),
 		}
 	}
 	return nil

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/limits.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/limits.go
@@ -40,7 +40,7 @@ func MaxLength[T ~string](_ context.Context, _ operation.Operation, fldPath *fie
 // MaxItems verifies that the specified slice is not longer than max items.
 func MaxItems[T any](_ context.Context, _ operation.Operation, fldPath *field.Path, value, _ []T, max int) field.ErrorList {
 	if len(value) > max {
-		return field.ErrorList{field.TooMany(fldPath, len(value), max)}
+		return field.ErrorList{field.TooMany(fldPath, len(value), max).WithOrigin("maxItems")}
 	}
 	return nil
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/required.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/required.go
@@ -30,7 +30,7 @@ func RequiredValue[T comparable](_ context.Context, _ operation.Operation, fldPa
 	if *value != zero {
 		return nil
 	}
-	return field.ErrorList{field.Required(fldPath, "")}
+	return field.ErrorList{field.Required(fldPath, "").WithOrigin("required")}
 }
 
 // RequiredPointer verifies that the specified pointer is not nil.
@@ -38,7 +38,7 @@ func RequiredPointer[T any](_ context.Context, _ operation.Operation, fldPath *f
 	if value != nil {
 		return nil
 	}
-	return field.ErrorList{field.Required(fldPath, "")}
+	return field.ErrorList{field.Required(fldPath, "").WithOrigin("required")}
 }
 
 // RequiredSlice verifies that the specified slice is not empty.
@@ -46,7 +46,7 @@ func RequiredSlice[T any](_ context.Context, _ operation.Operation, fldPath *fie
 	if len(value) > 0 {
 		return nil
 	}
-	return field.ErrorList{field.Required(fldPath, "")}
+	return field.ErrorList{field.Required(fldPath, "").WithOrigin("required")}
 }
 
 // RequiredMap verifies that the specified map is not empty.
@@ -54,7 +54,7 @@ func RequiredMap[K comparable, T any](_ context.Context, _ operation.Operation, 
 	if len(value) > 0 {
 		return nil
 	}
-	return field.ErrorList{field.Required(fldPath, "")}
+	return field.ErrorList{field.Required(fldPath, "").WithOrigin("required")}
 }
 
 // ForbiddenValue verifies that the specified value is the zero-value for its
@@ -64,7 +64,7 @@ func ForbiddenValue[T comparable](_ context.Context, _ operation.Operation, fldP
 	if *value == zero {
 		return nil
 	}
-	return field.ErrorList{field.Forbidden(fldPath, "")}
+	return field.ErrorList{field.Forbidden(fldPath, "").WithOrigin("forbidden")}
 }
 
 // ForbiddenPointer verifies that the specified pointer is nil.
@@ -72,7 +72,7 @@ func ForbiddenPointer[T any](_ context.Context, _ operation.Operation, fldPath *
 	if value == nil {
 		return nil
 	}
-	return field.ErrorList{field.Forbidden(fldPath, "")}
+	return field.ErrorList{field.Forbidden(fldPath, "").WithOrigin("forbidden")}
 }
 
 // ForbiddenSlice verifies that the specified slice is empty.
@@ -80,7 +80,7 @@ func ForbiddenSlice[T any](_ context.Context, _ operation.Operation, fldPath *fi
 	if len(value) == 0 {
 		return nil
 	}
-	return field.ErrorList{field.Forbidden(fldPath, "")}
+	return field.ErrorList{field.Forbidden(fldPath, "").WithOrigin("forbidden")}
 }
 
 // ForbiddenMap verifies that the specified map is empty.
@@ -88,7 +88,7 @@ func ForbiddenMap[K comparable, T any](_ context.Context, _ operation.Operation,
 	if len(value) == 0 {
 		return nil
 	}
-	return field.ErrorList{field.Forbidden(fldPath, "")}
+	return field.ErrorList{field.Forbidden(fldPath, "").WithOrigin("forbidden")}
 }
 
 // OptionalValue verifies that the specified value is not the zero-value for
@@ -119,7 +119,7 @@ func OptionalSlice[T any](_ context.Context, _ operation.Operation, fldPath *fie
 	if len(value) > 0 {
 		return nil
 	}
-	return field.ErrorList{field.Required(fldPath, "optional value was not specified")}
+	return field.ErrorList{field.Required(fldPath, "optional value was not specified").WithOrigin("optional")}
 }
 
 // OptionalMap verifies that the specified map is not empty. This is identical
@@ -129,5 +129,5 @@ func OptionalMap[K comparable, T any](_ context.Context, _ operation.Operation, 
 	if len(value) > 0 {
 		return nil
 	}
-	return field.ErrorList{field.Required(fldPath, "optional value was not specified")}
+	return field.ErrorList{field.Required(fldPath, "optional value was not specified").WithOrigin("optional")}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/union.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/union.go
@@ -72,7 +72,7 @@ func Union[T any](_ context.Context, op operation.Operation, fldPath *field.Path
 		},
 	}
 
-	return unionValidate(op, fldPath, obj, oldObj, union, options, isSetFns...)
+	return unionValidate(op, fldPath, obj, oldObj, union, options, isSetFns...).WithOrigin("union")
 }
 
 // DiscriminatedUnion verifies specified union member matches the discriminator.
@@ -134,7 +134,7 @@ func DiscriminatedUnion[T any, D ~string](_ context.Context, op operation.Operat
 	if op.Type == operation.Update && !changed {
 		return nil
 	}
-	return errs
+	return errs.WithOrigin("union")
 }
 
 // UnionMember represents a member of a union.

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/union_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/union_test.go
@@ -44,19 +44,19 @@ func TestUnion(t *testing.T) {
 			name:        "two members set",
 			fields:      []string{"a", "b", "c", "d"},
 			fieldValues: []bool{false, true, false, true},
-			expected:    field.ErrorList{field.Invalid(nil, "{b, d}", "must specify exactly one of: `a`, `b`, `c`, `d`")},
+			expected:    field.ErrorList{field.Invalid(nil, "{b, d}", "must specify exactly one of: `a`, `b`, `c`, `d`").WithOrigin("union")},
 		},
 		{
 			name:        "all members set",
 			fields:      []string{"a", "b", "c", "d"},
 			fieldValues: []bool{true, true, true, true},
-			expected:    field.ErrorList{field.Invalid(nil, "{a, b, c, d}", "must specify exactly one of: `a`, `b`, `c`, `d`")},
+			expected:    field.ErrorList{field.Invalid(nil, "{a, b, c, d}", "must specify exactly one of: `a`, `b`, `c`, `d`").WithOrigin("union")},
 		},
 		{
 			name:        "no member set",
 			fields:      []string{"a", "b", "c", "d"},
 			fieldValues: []bool{false, false, false, false},
-			expected:    field.ErrorList{field.Invalid(nil, "", "must specify one of: `a`, `b`, `c`, `d`")},
+			expected:    field.ErrorList{field.Invalid(nil, "", "must specify one of: `a`, `b`, `c`, `d`").WithOrigin("union")},
 		},
 	}
 
@@ -113,8 +113,8 @@ func TestDiscriminatedUnion(t *testing.T) {
 			discriminatorValue: "C",
 			fieldValues:        []bool{false, true, false, false},
 			expected: field.ErrorList{
-				field.Invalid(field.NewPath("b"), "", "may only be specified when `type` is \"B\""),
-				field.Invalid(field.NewPath("c"), "", "must be specified when `type` is \"C\""),
+				field.Invalid(field.NewPath("b"), "", "may only be specified when `type` is \"B\"").WithOrigin("union"),
+				field.Invalid(field.NewPath("c"), "", "must be specified when `type` is \"C\"").WithOrigin("union"),
 			},
 		},
 		{
@@ -124,8 +124,8 @@ func TestDiscriminatedUnion(t *testing.T) {
 			discriminatorValue: "C",
 			fieldValues:        []bool{false, true, true, true},
 			expected: field.ErrorList{
-				field.Invalid(field.NewPath("b"), "", "may only be specified when `type` is \"B\""),
-				field.Invalid(field.NewPath("d"), "", "may only be specified when `type` is \"D\""),
+				field.Invalid(field.NewPath("b"), "", "may only be specified when `type` is \"B\"").WithOrigin("union"),
+				field.Invalid(field.NewPath("d"), "", "may only be specified when `type` is \"D\"").WithOrigin("union"),
 			},
 		},
 	}
@@ -216,7 +216,7 @@ func TestUnionRatcheting(t *testing.T) {
 				M2: &m2{},
 			},
 			expected: field.ErrorList{
-				field.Invalid(nil, "{m1, m2}", "must specify exactly one of: `m1`, `m2`"),
+				field.Invalid(nil, "{m1, m2}", "must specify exactly one of: `m1`, `m2`").WithOrigin("union"),
 			},
 		},
 	}
@@ -311,7 +311,7 @@ func TestDiscriminatedUnionRatcheting(t *testing.T) {
 				M2: &m2{},
 			},
 			expected: field.ErrorList{
-				field.Invalid(field.NewPath("m2"), "", "may only be specified when `d` is \"m2\""),
+				field.Invalid(field.NewPath("m2"), "", "may only be specified when `d` is \"m2\"").WithOrigin("union"),
 			},
 		},
 		{
@@ -325,8 +325,8 @@ func TestDiscriminatedUnionRatcheting(t *testing.T) {
 				M1: &m1{},
 			},
 			expected: field.ErrorList{
-				field.Invalid(field.NewPath("m1"), "", "may only be specified when `d` is \"m1\""),
-				field.Invalid(field.NewPath("m2"), "", "must be specified when `d` is \"m2\""),
+				field.Invalid(field.NewPath("m1"), "", "may only be specified when `d` is \"m1\"").WithOrigin("union"),
+				field.Invalid(field.NewPath("m2"), "", "must be specified when `d` is \"m2\"").WithOrigin("union"),
 			},
 		},
 	}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/immutable/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/immutable/doc_test.go
@@ -65,15 +65,15 @@ func Test(t *testing.T) {
 	st.Value(&structA2).OldValue(&structA).ExpectValid()
 
 	st.Value(&structA).OldValue(&structB).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Forbidden(field.NewPath("stringField"), "immutable"),
-		field.Forbidden(field.NewPath("stringPtrField"), "immutable"),
-		field.Forbidden(field.NewPath("structField"), "immutable"),
-		field.Forbidden(field.NewPath("structPtrField"), "immutable"),
-		field.Forbidden(field.NewPath("noncomparableStructField"), "immutable"),
-		field.Forbidden(field.NewPath("noncomparableStructPtrField"), "immutable"),
-		field.Forbidden(field.NewPath("sliceField"), "immutable"),
-		field.Forbidden(field.NewPath("mapField"), "immutable"),
-		field.Forbidden(field.NewPath("immutableField"), "immutable"),
-		field.Forbidden(field.NewPath("immutablePtrField"), "immutable"),
+		field.Forbidden(field.NewPath("stringField"), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("stringPtrField"), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("structField"), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("structPtrField"), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("noncomparableStructField"), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("noncomparableStructPtrField"), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("sliceField"), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("mapField"), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("immutableField"), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("immutablePtrField"), "immutable").WithOrigin("immutable"),
 	})
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/immutable_transitions/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/immutable_transitions/doc_test.go
@@ -42,13 +42,13 @@ func Test(t *testing.T) {
 	}
 
 	st.Value(new).OldValue(old).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Forbidden(field.NewPath("listField").Index(0), "immutable"),
-		field.Forbidden(field.NewPath("listField").Index(1).Child("stringField"), "immutable"),
+		field.Forbidden(field.NewPath("listField").Index(0), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("listField").Index(1).Child("stringField"), "immutable").WithOrigin("immutable"),
 	})
 
 	st.Value(new).OldValue(&Struct{ListField: []Item{}}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Forbidden(field.NewPath("listField").Index(0), "immutable"),
-		field.Forbidden(field.NewPath("listField").Index(1).Child("stringField"), "immutable"),
+		field.Forbidden(field.NewPath("listField").Index(0), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("listField").Index(1).Child("stringField"), "immutable").WithOrigin("immutable"),
 	})
 
 	// Test that "c" can change independently

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/typedef/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/typedef/doc_test.go
@@ -53,7 +53,7 @@ func Test(t *testing.T) {
 		},
 	}
 	st.Value(newStruct).OldValue(oldStruct).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Forbidden(field.NewPath("typedefItems").Index(0), "immutable"),
+		field.Forbidden(field.NewPath("typedefItems").Index(0), "immutable").WithOrigin("immutable"),
 	})
 
 	// Test nested typedef (typedef of typedef).

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/doc_test.go
@@ -110,24 +110,24 @@ func TestUpdateCorrelation(t *testing.T) {
 	st.Value(&structA2).OldValue(&structA1).ExpectValid()
 
 	st.Value(&structA1).OldValue(&structB).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Forbidden(field.NewPath("listField").Index(0), "immutable"),
-		field.Forbidden(field.NewPath("listField").Index(1), "immutable"),
-		field.Forbidden(field.NewPath("listTypedefField").Index(0), "immutable"),
-		field.Forbidden(field.NewPath("listTypedefField").Index(1), "immutable"),
-		field.Forbidden(field.NewPath("typedefField").Index(0), "immutable"),
-		field.Forbidden(field.NewPath("typedefField").Index(1), "immutable"),
+		field.Forbidden(field.NewPath("listField").Index(0), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("listField").Index(1), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("listTypedefField").Index(0), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("listTypedefField").Index(1), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("typedefField").Index(0), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("typedefField").Index(1), "immutable").WithOrigin("immutable"),
 	})
 
 	st.Value(&structB).OldValue(&structA1).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Forbidden(field.NewPath("listField").Index(0), "immutable"),
-		field.Forbidden(field.NewPath("listField").Index(1), "immutable"),
-		field.Forbidden(field.NewPath("listField").Index(2), "immutable"),
-		field.Forbidden(field.NewPath("listTypedefField").Index(0), "immutable"),
-		field.Forbidden(field.NewPath("listTypedefField").Index(1), "immutable"),
-		field.Forbidden(field.NewPath("listTypedefField").Index(2), "immutable"),
-		field.Forbidden(field.NewPath("typedefField").Index(0), "immutable"),
-		field.Forbidden(field.NewPath("typedefField").Index(1), "immutable"),
-		field.Forbidden(field.NewPath("typedefField").Index(2), "immutable"),
+		field.Forbidden(field.NewPath("listField").Index(0), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("listField").Index(1), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("listField").Index(2), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("listTypedefField").Index(0), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("listTypedefField").Index(1), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("listTypedefField").Index(2), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("typedefField").Index(0), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("typedefField").Index(1), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("typedefField").Index(2), "immutable").WithOrigin("immutable"),
 	})
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/doc_test.go
@@ -111,24 +111,24 @@ func TestUpdateCorrelation(t *testing.T) {
 	st.Value(&structA2).OldValue(&structA1).ExpectValid()
 
 	st.Value(&structA1).OldValue(&structB).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Forbidden(field.NewPath("listField").Index(0), "immutable"),
-		field.Forbidden(field.NewPath("listField").Index(1), "immutable"),
-		field.Forbidden(field.NewPath("listTypedefField").Index(0), "immutable"),
-		field.Forbidden(field.NewPath("listTypedefField").Index(1), "immutable"),
-		field.Forbidden(field.NewPath("typedefField").Index(0), "immutable"),
-		field.Forbidden(field.NewPath("typedefField").Index(1), "immutable"),
+		field.Forbidden(field.NewPath("listField").Index(0), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("listField").Index(1), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("listTypedefField").Index(0), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("listTypedefField").Index(1), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("typedefField").Index(0), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("typedefField").Index(1), "immutable").WithOrigin("immutable"),
 	})
 
 	st.Value(&structB).OldValue(&structA1).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Forbidden(field.NewPath("listField").Index(0), "immutable"),
-		field.Forbidden(field.NewPath("listField").Index(1), "immutable"),
-		field.Forbidden(field.NewPath("listField").Index(2), "immutable"),
-		field.Forbidden(field.NewPath("listTypedefField").Index(0), "immutable"),
-		field.Forbidden(field.NewPath("listTypedefField").Index(1), "immutable"),
-		field.Forbidden(field.NewPath("listTypedefField").Index(2), "immutable"),
-		field.Forbidden(field.NewPath("typedefField").Index(0), "immutable"),
-		field.Forbidden(field.NewPath("typedefField").Index(1), "immutable"),
-		field.Forbidden(field.NewPath("typedefField").Index(2), "immutable"),
+		field.Forbidden(field.NewPath("listField").Index(0), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("listField").Index(1), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("listField").Index(2), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("listTypedefField").Index(0), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("listTypedefField").Index(1), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("listTypedefField").Index(2), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("typedefField").Index(0), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("typedefField").Index(1), "immutable").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("typedefField").Index(2), "immutable").WithOrigin("immutable"),
 	})
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/custom_members/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/custom_members/doc_test.go
@@ -29,11 +29,11 @@ func Test(t *testing.T) {
 	st.Value(&Struct{D: DM2, M2: &M2{}}).ExpectValid()
 
 	st.Value(&Struct{D: DM2, M1: &M1{}, M2: &M2{}}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Invalid(field.NewPath("m1"), nil, "may only be specified when"),
+		field.Invalid(field.NewPath("m1"), nil, "may only be specified when").WithOrigin("union"),
 	})
 
 	st.Value(&Struct{D: DM1}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Invalid(field.NewPath("m1"), nil, "must be specified when"),
+		field.Invalid(field.NewPath("m1"), nil, "must be specified when").WithOrigin("union"),
 	})
 
 	// Test validation ratcheting

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/multiple/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/multiple/doc_test.go
@@ -41,24 +41,24 @@ func Test(t *testing.T) {
 		D1: U1M2, U1M1: &M1{}, U1M2: &M2{},
 		D2: U2M2, // no value
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Invalid(field.NewPath("u1m1"), nil, "may only be specified when"),
-		field.Invalid(field.NewPath("u2m2"), nil, "must be specified when"),
+		field.Invalid(field.NewPath("u1m1"), nil, "may only be specified when").WithOrigin("union"),
+		field.Invalid(field.NewPath("u2m2"), nil, "must be specified when").WithOrigin("union"),
 	})
 
 	st.Value(&Struct{
 		D1: U1M2, // no value
 		D2: U2M2, U2M1: &M1{}, U2M2: &M2{},
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Invalid(field.NewPath("u1m2"), nil, "must be specified when"),
-		field.Invalid(field.NewPath("u2m1"), nil, "may only be specified when"),
+		field.Invalid(field.NewPath("u1m2"), nil, "must be specified when").WithOrigin("union"),
+		field.Invalid(field.NewPath("u2m1"), nil, "may only be specified when").WithOrigin("union"),
 	})
 
 	st.Value(&Struct{
 		D1: U1M2, // no value
 		D2: U2M2, // no value
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Invalid(field.NewPath("u1m2"), nil, "must be specified when"),
-		field.Invalid(field.NewPath("u2m2"), nil, "must be specified when"),
+		field.Invalid(field.NewPath("u1m2"), nil, "must be specified when").WithOrigin("union"),
+		field.Invalid(field.NewPath("u2m2"), nil, "must be specified when").WithOrigin("union"),
 	})
 
 	// Test validation ratcheting

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/simple/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/simple/doc_test.go
@@ -31,11 +31,11 @@ func Test(t *testing.T) {
 	st.Value(&Struct{D: DM2, M2: &M2{}}).ExpectValid()
 
 	st.Value(&Struct{D: DM2, M1: &M1{}, M2: &M2{}}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Invalid(field.NewPath("m1"), nil, "may only be specified when"),
+		field.Invalid(field.NewPath("m1"), nil, "may only be specified when").WithOrigin("union"),
 	})
 
 	st.Value(&Struct{D: DM1}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Invalid(field.NewPath("m1"), nil, "must be specified when"),
+		field.Invalid(field.NewPath("m1"), nil, "must be specified when").WithOrigin("union"),
 	})
 
 	// Test validation ratcheting

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/sparse/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/discriminated/sparse/doc_test.go
@@ -31,11 +31,11 @@ func Test(t *testing.T) {
 	st.Value(&Struct{D: DM2}).ExpectValid()
 
 	st.Value(&Struct{D: DM2, M1: &M1{}}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Invalid(field.NewPath("m1"), nil, "may only be specified when"),
+		field.Invalid(field.NewPath("m1"), nil, "may only be specified when").WithOrigin("union"),
 	})
 
 	st.Value(&Struct{D: DM1}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Invalid(field.NewPath("m1"), nil, "must be specified when"),
+		field.Invalid(field.NewPath("m1"), nil, "must be specified when").WithOrigin("union"),
 	})
 
 	// Test validation ratcheting

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/custom_members/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/custom_members/doc_test.go
@@ -29,10 +29,10 @@ func Test(t *testing.T) {
 	st.Value(&Struct{M2: &M2{}}).ExpectValid()
 
 	st.Value(&Struct{M1: &M1{}, M2: &M2{}}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Invalid(nil, nil, "must specify exactly one of"),
+		field.Invalid(nil, nil, "must specify exactly one of").WithOrigin("union"),
 	})
 	st.Value(&Struct{}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Invalid(nil, nil, "must specify one of"),
+		field.Invalid(nil, nil, "must specify one of").WithOrigin("union"),
 	})
 
 	// Test validation ratcheting

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/multiple/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/multiple/doc_test.go
@@ -26,29 +26,27 @@ func Test(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
 	st.Value(&Struct{}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Invalid(nil, nil, "must specify one of"),
-		field.Invalid(nil, nil, "must specify one of"),
+		field.Invalid(nil, nil, "must specify one of").WithOrigin("union"),
 	})
 
 	st.Value(&Struct{U1M1: &M1{}, U2M1: &M1{}}).ExpectValid()
 	st.Value(&Struct{U1M2: &M2{}, U2M2: &M2{}}).ExpectValid()
 
 	st.Value(&Struct{U1M1: &M1{}, U1M2: &M2{}}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Invalid(nil, nil, "must specify exactly one of"),
-		field.Invalid(nil, nil, "must specify one of"),
+		field.Invalid(nil, nil, "must specify exactly one of").WithOrigin("union"),
+		field.Invalid(nil, nil, "must specify one of").WithOrigin("union"),
 	})
 
 	st.Value(&Struct{U2M1: &M1{}, U2M2: &M2{}}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Invalid(nil, nil, "must specify one of"),
-		field.Invalid(nil, nil, "must specify exactly one of"),
+		field.Invalid(nil, nil, "must specify one of").WithOrigin("union"),
+		field.Invalid(nil, nil, "must specify exactly one of").WithOrigin("union"),
 	})
 
 	st.Value(&Struct{
 		U1M1: &M1{}, U1M2: &M2{},
 		U2M1: &M1{}, U2M2: &M2{},
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Invalid(nil, nil, "must specify exactly one of"),
-		field.Invalid(nil, nil, "must specify exactly one of"),
+		field.Invalid(nil, nil, "must specify exactly one of").WithOrigin("union"),
 	})
 
 	// Test validation ratcheting

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/simple/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/undiscriminated/simple/doc_test.go
@@ -27,7 +27,7 @@ func Test(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
 	st.Value(&Struct{}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Invalid(nil, nil, "must specify one of"),
+		field.Invalid(nil, nil, "must specify one of").WithOrigin("union"),
 	})
 
 	st.Value(&Struct{M1: &M1{}}).ExpectValid()
@@ -36,13 +36,13 @@ func Test(t *testing.T) {
 	st.Value(&Struct{M4: ptr.To("a string")}).ExpectValid()
 
 	st.Value(&Struct{M1: &M1{}, M2: &M2{}}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Invalid(nil, nil, "must specify exactly one of"),
+		field.Invalid(nil, nil, "must specify exactly one of").WithOrigin("union"),
 	})
 	st.Value(&Struct{M1: &M1{}, M3: "a string"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Invalid(nil, nil, "must specify exactly one of"),
+		field.Invalid(nil, nil, "must specify exactly one of").WithOrigin("union"),
 	})
 	st.Value(&Struct{M1: &M1{}, M4: ptr.To("a string")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Invalid(nil, nil, "must specify exactly one of"),
+		field.Invalid(nil, nil, "must specify exactly one of").WithOrigin("union"),
 	})
 
 	// Update only considers whether a field was set, not the value.

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitive_pointers/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitive_pointers/doc_test.go
@@ -53,9 +53,9 @@ func Test(t *testing.T) {
 	st.Value(&structA1).OldValue(&structA2).ExpectValid()
 
 	st.Value(&structA1).OldValue(&structB).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Forbidden(field.NewPath("sp"), ""),
-		field.Forbidden(field.NewPath("ip"), ""),
-		field.Forbidden(field.NewPath("bp"), ""),
-		field.Forbidden(field.NewPath("fp"), ""),
+		field.Forbidden(field.NewPath("sp"), "").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("ip"), "").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("bp"), "").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("fp"), "").WithOrigin("immutable"),
 	})
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitives/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitives/doc_test.go
@@ -43,9 +43,9 @@ func Test(t *testing.T) {
 	st.Value(&structA).OldValue(&structA).ExpectValid()
 
 	st.Value(&structA).OldValue(&structB).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Forbidden(field.NewPath("s"), ""),
-		field.Forbidden(field.NewPath("i"), ""),
-		field.Forbidden(field.NewPath("b"), ""),
-		field.Forbidden(field.NewPath("f"), ""),
+		field.Forbidden(field.NewPath("s"), "").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("i"), "").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("b"), "").WithOrigin("immutable"),
+		field.Forbidden(field.NewPath("f"), "").WithOrigin("immutable"),
 	})
 }


### PR DESCRIPTION
This PR adds an "origin" to validation errors, which helps identify the source of a validation rule. This is useful for matching and filtering errors.

Test Cases have updated to match with the validation errors origin. 

Fixes: https://github.com/jpbetz/validation-gen/issues/155