### PR TITLE
Fix failing test

### DIFF
--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -7515,7 +7515,7 @@ func TestGeneratePodHostNameAndDomain(t *testing.T) {
 			podName:       "test-pod",
 			podHostname:   strings.Repeat("a", 64),
 			expectError:   true,
-			errorContains: "must be no more than 63 characters",
+			errorContains: "must be no more than 63 bytes",
 		},
 	}
 


### PR DESCRIPTION
This test is failing for the project. Providing wrong signals in local testing.

This new test case came in from the reset rebase.


k/k is using "must be no more than %d characters"  for MaxLenError but validation-gen is using "must be no more than %d bytes" . I am assuming we would like to CP Validation-gen behaviour to k/k eventually. This change was introduced in validation-gen here.

https://github.com/jpbetz/validation-gen/commit/7eddef4062babe75d144a8ebbd62694800aa02dd#diff-96cb3b751355fb5859de46cdd21f8dbe6a36f155c49c4ccec0455fac3a821de7