### PR TITLE
feat: add path translation support to the error matcher

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/error_matcher.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/error_matcher.go
@@ -50,7 +50,10 @@ type ErrorMatcher struct {
 }
 
 // Matches returns true if the two Error objects match according to the
-// configured criteria.
+// configured criteria. When field normalization is configured, only the
+// "got" error's field path is normalized (to bring older API versions up
+// to the internal/latest format), while "want" is assumed to already be
+// in the canonical internal API format.
 func (m ErrorMatcher) Matches(want, got *Error) bool {
 	if m.matchType && want.Type != got.Type {
 		return false
@@ -59,9 +62,10 @@ func (m ErrorMatcher) Matches(want, got *Error) bool {
 		// Try direct match first (common case)
 		if want.Field != got.Field {
 			// Fields don't match, try normalization if rules are configured.
-			wantField := m.normalizePath(want.Field)
-			gotField := m.normalizePath(got.Field)
-			if wantField != gotField {
+			// Only normalize "got" - it may be from an older API version that
+			// needs to be brought up to the internal/latest format that "want"
+			// is already in.
+			if want.Field != m.normalizePath(got.Field) {
 				return false
 			}
 		}
@@ -176,8 +180,14 @@ func (m ErrorMatcher) ByField() ErrorMatcher {
 }
 
 // ByFieldNormalized returns a derived ErrorMatcher which also matches by field path
-// after applying a set of normalization rules.
-// This allows matching equivalent field paths across different API versions.
+// after applying normalization rules to the actual (got) error's field path.
+// This allows matching field paths from older API versions against the canonical
+// internal API format.
+//
+// The normalization rules are applied ONLY to the "got" error's field path, bringing
+// older API version field paths up to the latest/internal format. The "want" error
+// is assumed to always be in the internal API format (latest).
+//
 // The rules slice holds pre-compiled regular expressions and their replacement strings.
 //
 // Example:
@@ -266,11 +276,14 @@ type TestIntf interface {
 }
 
 // Test compares two ErrorLists by the criteria configured in this matcher, and
-// fails the test if they don't match. If matching by origin is enabled and the
-// error has a non-empty origin, a given "want" error can match multiple
-// "got" errors, and they will all be consumed. The only exception to this is
-// if the matcher got multiple identical (in every way, even those not being
-// matched on) errors, which is likely to indicate a bug.
+// fails the test if they don't match. The "want" errors are expected to be in
+// the internal API format (latest), while "got" errors may be from any API version
+// and will be normalized if field normalization rules are configured.
+//
+// If matching by origin is enabled and the error has a non-empty origin, a given
+// "want" error can match multiple "got" errors, and they will all be consumed.
+// The only exception to this is if the matcher got multiple identical (in every way,
+// even those not being matched on) errors, which is likely to indicate a bug.
 func (m ErrorMatcher) Test(tb TestIntf, want, got ErrorList) {
 	tb.Helper()
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/error_matcher_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/error_matcher_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -65,19 +65,7 @@ func TestErrorMatcher_Matches(t *testing.T) {
 		actualErr: &Error{Field: "other"},
 		matches:   false,
 	}, {
-		name: "ByFieldNormalized: v1beta1 to v1",
-		matcher: ErrorMatcher{}.ByFieldNormalized([]NormalizationRule{
-			{Regexp: regexp.MustCompile(`f\[(\d+)\]\.a`), Replacement: "f[$1].x.a"},
-		}),
-		wantedErr: func() *Error {
-			e := baseErr()
-			e.Field = "f[0].a"
-			return e
-		},
-		actualErr: &Error{Field: "f[0].x.a"},
-		matches:   true,
-	}, {
-		name: "ByFieldNormalized: v1 to v1beta1",
+		name: "ByFieldNormalized: older API to latest",
 		matcher: ErrorMatcher{}.ByFieldNormalized([]NormalizationRule{
 			{Regexp: regexp.MustCompile(`f\[(\d+)\]\.a`), Replacement: "f[$1].x.a"},
 		}),
@@ -89,16 +77,28 @@ func TestErrorMatcher_Matches(t *testing.T) {
 		actualErr: &Error{Field: "f[0].a"},
 		matches:   true,
 	}, {
+		name: "ByFieldNormalized: both latest format",
+		matcher: ErrorMatcher{}.ByFieldNormalized([]NormalizationRule{
+			{Regexp: regexp.MustCompile(`f\[(\d+)\]\.a`), Replacement: "f[$1].x.a"},
+		}),
+		wantedErr: func() *Error {
+			e := baseErr()
+			e.Field = "f[0].x.a"
+			return e
+		},
+		actualErr: &Error{Field: "f[0].x.a"},
+		matches:   true,
+	}, {
 		name: "ByFieldNormalized: different index",
 		matcher: ErrorMatcher{}.ByFieldNormalized([]NormalizationRule{
 			{Regexp: regexp.MustCompile(`f\[(\d+)\]\.a`), Replacement: "f[$1].x.a"},
 		}),
 		wantedErr: func() *Error {
 			e := baseErr()
-			e.Field = "f[0].a"
+			e.Field = "f[0].x.a"
 			return e
 		},
-		actualErr: &Error{Field: "f[1].x.a"},
+		actualErr: &Error{Field: "f[1].a"},
 		matches:   false,
 	}, {
 		name: "ByFieldNormalized: multiple patterns",
@@ -108,13 +108,13 @@ func TestErrorMatcher_Matches(t *testing.T) {
 		}),
 		wantedErr: func() *Error {
 			e := baseErr()
-			e.Field = "f[2].b"
+			e.Field = "f[2].x.b"
 			return e
 		},
-		actualErr: &Error{Field: "f[2].x.b"},
+		actualErr: &Error{Field: "f[2].b"},
 		matches:   true,
 	}, {
-		name: "ByFieldNormalized: no normalization",
+		name: "ByFieldNormalized: no normalization needed",
 		matcher: ErrorMatcher{}.ByFieldNormalized([]NormalizationRule{
 			{Regexp: regexp.MustCompile(`f\[(\d+)\]\.a`), Replacement: "f[$1].x.a"},
 		}),
@@ -391,19 +391,19 @@ func TestErrorMatcher_Test(t *testing.T) {
 		got:            ErrorList{Invalid(NewPath("f2"), "v", "d")},
 		expectedErrors: []string{"expected an error matching:", "unmatched error:"},
 	}, {
-		name: "with normalization: match",
-		matcher: ErrorMatcher{}.ByFieldNormalized([]NormalizationRule{
-			{Regexp: regexp.MustCompile(`f\[(\d+)\]\.a`), Replacement: "f[$1].x.a"},
-		}),
-		want: ErrorList{Invalid(NewPath("f").Index(0).Child("a"), nil, "")},
-		got:  ErrorList{Invalid(NewPath("f").Index(0).Child("x", "a"), "v", "d")},
-	}, {
-		name: "with normalization: reverse match",
+		name: "with normalization: older API to latest",
 		matcher: ErrorMatcher{}.ByFieldNormalized([]NormalizationRule{
 			{Regexp: regexp.MustCompile(`f\[(\d+)\]\.a`), Replacement: "f[$1].x.a"},
 		}),
 		want: ErrorList{Invalid(NewPath("f").Index(0).Child("x", "a"), nil, "")},
 		got:  ErrorList{Invalid(NewPath("f").Index(0).Child("a"), "v", "d")},
+	}, {
+		name: "with normalization: both latest",
+		matcher: ErrorMatcher{}.ByFieldNormalized([]NormalizationRule{
+			{Regexp: regexp.MustCompile(`f\[(\d+)\]\.a`), Replacement: "f[$1].x.a"},
+		}),
+		want: ErrorList{Invalid(NewPath("f").Index(0).Child("x", "a"), nil, "")},
+		got:  ErrorList{Invalid(NewPath("f").Index(0).Child("x", "a"), "v", "d")},
 	}, {
 		name: "with normalization: multiple",
 		matcher: ErrorMatcher{}.ByFieldNormalized([]NormalizationRule{
@@ -411,20 +411,20 @@ func TestErrorMatcher_Test(t *testing.T) {
 			{Regexp: regexp.MustCompile(`f\[(\d+)\]\.b`), Replacement: "f[$1].x.b"},
 		}),
 		want: ErrorList{
-			Invalid(NewPath("f").Index(0).Child("a"), nil, ""),
-			Invalid(NewPath("f").Index(1).Child("b"), nil, ""),
+			Invalid(NewPath("f").Index(0).Child("x", "a"), nil, ""),
+			Invalid(NewPath("f").Index(1).Child("x", "b"), nil, ""),
 		},
 		got: ErrorList{
-			Invalid(NewPath("f").Index(0).Child("x", "a"), "v1", "d1"),
-			Invalid(NewPath("f").Index(1).Child("x", "b"), "v2", "d2"),
+			Invalid(NewPath("f").Index(0).Child("a"), "v1", "d1"),
+			Invalid(NewPath("f").Index(1).Child("b"), "v2", "d2"),
 		},
 	}, {
 		name: "with normalization: no match",
 		matcher: ErrorMatcher{}.ByFieldNormalized([]NormalizationRule{
 			{Regexp: regexp.MustCompile(`f\[(\d+)\]\.a`), Replacement: "f[$1].x.a"},
 		}),
-		want:           ErrorList{Invalid(NewPath("f").Index(0).Child("a"), nil, "")},
-		got:            ErrorList{Invalid(NewPath("f").Index(1).Child("x", "a"), "v", "d")},
+		want:           ErrorList{Invalid(NewPath("f").Index(0).Child("x", "a"), nil, "")},
+		got:            ErrorList{Invalid(NewPath("f").Index(1).Child("a"), "v", "d")},
 		expectedErrors: []string{"expected an error matching:", "unmatched error:"},
 	}, {
 		name:    "declarative only: match",


### PR DESCRIPTION
Adds path translation support to the error matcher.  Usage is like:
```go
pathTranslations := map[string]string{
  `spec\.devices\.requests\[(\d+)\]\.allocationMode`: "spec.devices.requests[$1].exactly.allocationMode",
}
matcher := ErrorMatcher{}.ByField(pathTranslations)
```

Related design document: https://docs.google.com/document/d/1EQR7qBrLSZZ0MoHpkEwo-scjAVRRosf5XsaUHtABpo0/edit?resourcekey=0-d0fA01bllcGK3JtUEPZ6ZQ&tab=t.0

Currently this uses regexp to handle "dynamic" parts of the field path being translated such as list indices or map keys.  I believe that once fully plumbed, this translation logic would be called on every request where the initial equality check fails (a small optimization).  This is because the error matcher is used for all errors for the DeclarativeValidationMismatchMetric check.  As such, for each validation where  the initial equality check fails (a small optimization) we would run N regexp on the "want" and "got" strings.  I am not sure what N will be, a very rough estimate would be in the 100-500 range (it is per field).  

Currently the optimizations here include:
- storing compiled regexes
- only attempted to normalize a field path with the N regexes after an initial equality check fails

The alternative to this noted in the document would be matching the the suffix which currently is deemed worse as it allows more amiguity (can't distinguish fields with same name across one object, etc.)

Benchmark test information:

benchmark test: https://gist.github.com/aaron-prindle/7dbe934092717d1b047d0e7aba5dc171
```
aprindle@aprindle-ssd-v2 ~/validation-gen/staging/src/k8s.io/apimachinery/pkg/util/validation/field  [error-matcher-path-translation-ft]go test -bench=. -run=^$ -benchmem
goos: linux
goarch: amd64
pkg: k8s.io/apimachinery/pkg/util/validation/field
cpu: AMD EPYC 7B13
BenchmarkErrorMatcher_Matches_PathNormalization/NoNormalization-8         	90231583	        12.86 ns/op	       0 B/op	       0 allocs/op
BenchmarkErrorMatcher_Matches_PathNormalization/100Rules_WorstCase-8      	   28746	     43104 ns/op	   14465 B/op	     300 allocs/op
BenchmarkErrorMatcher_Matches_PathNormalization/1000Rules_WorstCase-8     	    2422	    442153 ns/op	  144670 B/op	    3000 allocs/op
PASS
ok  	k8s.io/apimachinery/pkg/util/validation/field	4.660s
```