### PR TITLE
fix: make +k8s:immutable tag have Invalid error (vs Forbidden) to better match hand-written usage

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/immutable.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/immutable.go
@@ -35,6 +35,6 @@ func Immutable[T any](_ context.Context, op operation.Operation, fldPath *field.
 		return nil
 	}
 	return field.ErrorList{
-		field.Forbidden(fldPath, "field is immutable").WithOrigin("immutable"),
+		field.Invalid(fldPath, nil, "field is immutable").WithOrigin("immutable"),
 	}
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/immutable/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/immutable/doc_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -65,15 +65,15 @@ func Test(t *testing.T) {
 	st.Value(&structA2).OldValue(&structA).ExpectValid()
 
 	st.Value(&structA).OldValue(&structB).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin(), field.ErrorList{
-		field.Forbidden(field.NewPath("stringField"), "").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("stringPtrField"), "").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("structField"), "").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("structPtrField"), "").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("noncomparableStructField"), "").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("noncomparableStructPtrField"), "").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("sliceField"), "").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("mapField"), "").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("immutableField"), "").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("immutablePtrField"), "").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("stringField"), nil, "").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("stringPtrField"), nil, "").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("structField"), nil, "").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("structPtrField"), nil, "").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("noncomparableStructField"), nil, "").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("noncomparableStructPtrField"), nil, "").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("sliceField"), nil, "").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("mapField"), nil, "").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("immutableField"), nil, "").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("immutablePtrField"), nil, "").WithOrigin("immutable"),
 	})
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/immutable_transitions/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/immutable_transitions/doc_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -42,13 +42,13 @@ func Test(t *testing.T) {
 	}
 
 	st.Value(new).OldValue(old).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Forbidden(field.NewPath("listField").Index(0), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("listField").Index(1).Child("stringField"), "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("listField").Index(0), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("listField").Index(1).Child("stringField"), nil, "immutable").WithOrigin("immutable"),
 	})
 
 	st.Value(new).OldValue(&Struct{ListField: []Item{}}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Forbidden(field.NewPath("listField").Index(0), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("listField").Index(1).Child("stringField"), "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("listField").Index(0), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("listField").Index(1).Child("stringField"), nil, "immutable").WithOrigin("immutable"),
 	})
 
 	// Test that "c" can change independently

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/typedef/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/typedef/doc_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -53,7 +53,7 @@ func Test(t *testing.T) {
 		},
 	}
 	st.Value(newStruct).OldValue(oldStruct).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Forbidden(field.NewPath("typedefItems").Index(0), "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("typedefItems").Index(0), nil, "immutable").WithOrigin("immutable"),
 	})
 
 	// Test nested typedef (typedef of typedef).

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/doc_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -106,24 +106,24 @@ func TestUpdateCorrelation(t *testing.T) {
 	st.Value(&structA2).OldValue(&structA1).ExpectValid()
 
 	st.Value(&structA1).OldValue(&structB).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Forbidden(field.NewPath("listField").Index(0), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("listField").Index(1), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("listTypedefField").Index(0), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("listTypedefField").Index(1), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("typedefField").Index(0), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("typedefField").Index(1), "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("listField").Index(0), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("listField").Index(1), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("listTypedefField").Index(0), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("listTypedefField").Index(1), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("typedefField").Index(0), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("typedefField").Index(1), nil, "immutable").WithOrigin("immutable"),
 	})
 
 	st.Value(&structB).OldValue(&structA1).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Forbidden(field.NewPath("listField").Index(0), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("listField").Index(1), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("listField").Index(2), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("listTypedefField").Index(0), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("listTypedefField").Index(1), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("listTypedefField").Index(2), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("typedefField").Index(0), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("typedefField").Index(1), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("typedefField").Index(2), "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("listField").Index(0), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("listField").Index(1), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("listField").Index(2), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("listTypedefField").Index(0), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("listTypedefField").Index(1), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("listTypedefField").Index(2), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("typedefField").Index(0), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("typedefField").Index(1), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("typedefField").Index(2), nil, "immutable").WithOrigin("immutable"),
 	})
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/doc_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -107,24 +107,24 @@ func TestUpdateCorrelation(t *testing.T) {
 	st.Value(&structA2).OldValue(&structA1).ExpectValid()
 
 	st.Value(&structA1).OldValue(&structB).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Forbidden(field.NewPath("listField").Index(0), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("listField").Index(1), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("listTypedefField").Index(0), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("listTypedefField").Index(1), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("typedefField").Index(0), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("typedefField").Index(1), "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("listField").Index(0), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("listField").Index(1), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("listTypedefField").Index(0), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("listTypedefField").Index(1), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("typedefField").Index(0), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("typedefField").Index(1), nil, "immutable").WithOrigin("immutable"),
 	})
 
 	st.Value(&structB).OldValue(&structA1).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
-		field.Forbidden(field.NewPath("listField").Index(0), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("listField").Index(1), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("listField").Index(2), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("listTypedefField").Index(0), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("listTypedefField").Index(1), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("listTypedefField").Index(2), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("typedefField").Index(0), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("typedefField").Index(1), "immutable").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("typedefField").Index(2), "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("listField").Index(0), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("listField").Index(1), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("listField").Index(2), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("listTypedefField").Index(0), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("listTypedefField").Index(1), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("listTypedefField").Index(2), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("typedefField").Index(0), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("typedefField").Index(1), nil, "immutable").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("typedefField").Index(2), nil, "immutable").WithOrigin("immutable"),
 	})
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitive_pointers/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitive_pointers/doc_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -53,9 +53,9 @@ func Test(t *testing.T) {
 	st.Value(&structA1).OldValue(&structA2).ExpectValid()
 
 	st.Value(&structA1).OldValue(&structB).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin().ByDeclarativeOnly(), field.ErrorList{
-		field.Forbidden(field.NewPath("sp"), "").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("ip"), "").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("bp"), "").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("fp"), "").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("sp"), nil, "").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("ip"), nil, "").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("bp"), nil, "").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("fp"), nil, "").WithOrigin("immutable"),
 	})
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitives/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitives/doc_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -43,9 +43,9 @@ func Test(t *testing.T) {
 	st.Value(&structA).OldValue(&structA).ExpectValid()
 
 	st.Value(&structA).OldValue(&structB).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin().ByDeclarativeOnly(), field.ErrorList{
-		field.Forbidden(field.NewPath("s"), "").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("i"), "").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("b"), "").WithOrigin("immutable"),
-		field.Forbidden(field.NewPath("f"), "").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("s"), nil, "").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("i"), nil, "").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("b"), nil, "").WithOrigin("immutable"),
+		field.Invalid(field.NewPath("f"), nil, "").WithOrigin("immutable"),
 	})
 }


### PR DESCRIPTION
This PR changes +k8s:immutable to output an Invalid error (vs Forbidden) .  This is to align with the kubernetes `ValidateImmutableField`:

https://github.com/kubernetes/kubernetes/blob/8f372d2ac06c78707a92c1e88e5e0bb1fc5b59aa/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go#L130-L137

```go
// ValidateImmutableField validates the new value and the old value are deeply equal.
func ValidateImmutableField(newVal, oldVal interface{}, fldPath *field.Path) field.ErrorList {
	allErrs := field.ErrorList{}
	if !apiequality.Semantic.DeepEqual(oldVal, newVal) {
		allErrs = append(allErrs, field.Invalid(fldPath, newVal, FieldImmutableErrorMsg))
	}
	return allErrs
}
```