### PR TITLE
feat: Promote subfield validation to stable

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/native/basics/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/native/basics/doc.go
@@ -93,6 +93,13 @@ type MyObject struct {
 
 	NestedStableWithoutDV NestedStableType `json:"nestedStableWithoutDV"`
 
+	// +k8s:subfield(innerField)=+k8s:maxLength=5
+	// +k8s:declarativeValidationNative
+	SubfieldTest StableType `json:"subfieldTest"`
+
+	// +k8s:subfield(innerField)=+k8s:maxLength=5
+	SubfieldTestWithoutDV StableType `json:"subfieldTestWithoutDV"`
+
 	// +k8s:optional
 	// +k8s:format=k8s-ip
 	// +k8s:declarativeValidationNative

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/native/basics/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/native/basics/doc_test.go
@@ -46,6 +46,8 @@ func TestMyObjectValidation(t *testing.T) {
 		SetListWithoutDV:                []string{"a", "b"},
 		NestedStable:                    NestedStableType{NestedField: StableType{InnerField: "abc"}, NestedFieldWithoutDV: StableType{InnerField: "abc"}},
 		NestedStableWithoutDV:           NestedStableType{NestedField: StableType{InnerField: "abc"}, NestedFieldWithoutDV: StableType{InnerField: "abc"}},
+		SubfieldTest:                    StableType{InnerField: "abcde"},
+		SubfieldTestWithoutDV:           StableType{InnerField: "abcde"},
 		IPAddress:                       "1.2.3.4",
 		IPAddressWithoutDV:              "1.2.3.4",
 	}
@@ -143,6 +145,19 @@ func TestMyObjectValidation(t *testing.T) {
 				field.Required(field.NewPath("nestedStable", "nestedFieldWithoutDV", "innerField"), "").MarkDeclarativeOnly(),
 				field.Required(field.NewPath("nestedStableWithoutDV", "nestedFieldWithoutDV", "innerField"), ""),
 				field.Required(field.NewPath("nestedStableWithoutDV", "nestedField", "innerField"), "").MarkDeclarativeOnly(),
+			},
+		},
+		{
+			name: "subfield",
+			obj: func() MyObject {
+				obj := validObj.DeepCopy()
+				obj.SubfieldTest.InnerField = "abcdefg"
+				obj.SubfieldTestWithoutDV.InnerField = "abcdefg"
+				return *obj
+			}(),
+			errs: field.ErrorList{
+				field.TooLong(field.NewPath("subfieldTest", "innerField"), "abcdefg", 5).MarkDeclarativeOnly(),
+				field.TooLong(field.NewPath("subfieldTestWithoutDV", "innerField"), "abcdefg", 5),
 			},
 		},
 		{

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/native/basics/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/native/basics/zz_generated.deepcopy.go
@@ -68,6 +68,8 @@ func (in *MyObject) DeepCopyInto(out *MyObject) {
 	}
 	out.NestedStable = in.NestedStable
 	out.NestedStableWithoutDV = in.NestedStableWithoutDV
+	out.SubfieldTest = in.SubfieldTest
+	out.SubfieldTestWithoutDV = in.SubfieldTestWithoutDV
 	return
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/native/basics/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/native/basics/zz_generated.validations.go
@@ -362,6 +362,46 @@ func Validate_MyObject(ctx context.Context, op operation.Operation, fldPath *fie
 			return
 		}(fldPath.Child("nestedStableWithoutDV"), &obj.NestedStableWithoutDV, safe.Field(oldObj, func(oldObj *MyObject) *NestedStableType { return &oldObj.NestedStableWithoutDV }), oldObj != nil)...)
 
+	// field MyObject.SubfieldTest
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *StableType, oldValueCorrelated bool) (errs field.ErrorList) {
+			// this field validations are marked declarative only
+			defer func() {
+				errs = errs.MarkDeclarativeOnly()
+			}()
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			func() { // cohort innerField
+				errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "innerField", func(o *StableType) *string { return &o.InnerField }, validate.DirectEqualPtr, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+					return validate.MaxLength(ctx, op, fldPath, obj, oldObj, 5)
+				})...)
+			}()
+			// call the type's validation function
+			errs = append(errs, Validate_StableType(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("subfieldTest"), &obj.SubfieldTest, safe.Field(oldObj, func(oldObj *MyObject) *StableType { return &oldObj.SubfieldTest }), oldObj != nil)...)
+
+	// field MyObject.SubfieldTestWithoutDV
+	errs = append(errs,
+		func(fldPath *field.Path, obj, oldObj *StableType, oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
+				return nil
+			}
+			// call field-attached validations
+			func() { // cohort innerField
+				errs = append(errs, validate.Subfield(ctx, op, fldPath, obj, oldObj, "innerField", func(o *StableType) *string { return &o.InnerField }, validate.DirectEqualPtr, func(ctx context.Context, op operation.Operation, fldPath *field.Path, obj, oldObj *string) field.ErrorList {
+					return validate.MaxLength(ctx, op, fldPath, obj, oldObj, 5)
+				})...)
+			}()
+			// call the type's validation function
+			errs = append(errs, Validate_StableType(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}(fldPath.Child("subfieldTestWithoutDV"), &obj.SubfieldTestWithoutDV, safe.Field(oldObj, func(oldObj *MyObject) *StableType { return &oldObj.SubfieldTestWithoutDV }), oldObj != nil)...)
+
 	// field MyObject.IPAddress
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/subfield.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/subfield.go
@@ -134,7 +134,7 @@ func (stv subfieldTagValidator) GetValidations(context Context, tag codetags.Tag
 func (stv subfieldTagValidator) Docs() TagDoc {
 	doc := TagDoc{
 		Tag:            stv.TagName(),
-		StabilityLevel: Beta,
+		StabilityLevel: Stable,
 		Scopes:         stv.ValidScopes().UnsortedList(),
 		Description:    "Declares a validation for a subfield of a struct.",
 		Args: []TagArgDoc{{


### PR DESCRIPTION
This PR promotes the `subfield` validation from Beta to Stable. It also adds tests for `subfield` with and without declarative validation to ensure its correctness.

/kind feature

#### What this PR does / why we need it:

This PR promotes the `subfield` validation from Beta to Stable. It also adds tests for `subfield` with and without declarative validation to ensure its correctness.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?
```release-note
Promote subfield validation to stable.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

