### PR TITLE
strategy.go : support declarative native validation

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/error_matcher.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/error_matcher.go
@@ -44,7 +44,7 @@ type ErrorMatcher struct {
 	matchOrigin              bool
 	matchDetail              func(want, got string) bool
 	requireOriginWhenInvalid bool
-	matchDeclarativeOnly     bool
+	matchDeclarativeNative   bool
 	// normalizationRules holds the pre-compiled regex patterns for path normalization.
 	normalizationRules []NormalizationRule
 }
@@ -87,7 +87,7 @@ func (m ErrorMatcher) Matches(want, got *Error) bool {
 	if m.matchDetail != nil && !m.matchDetail(want.Detail, got.Detail) {
 		return false
 	}
-	if m.matchDeclarativeOnly && want.DeclarativeOnly != got.DeclarativeOnly {
+	if m.matchDeclarativeNative && want.DeclarativeNative != got.DeclarativeNative {
 		return false
 	}
 
@@ -153,9 +153,9 @@ func (m ErrorMatcher) Render(e *Error) string {
 		comma()
 		buf.WriteString(fmt.Sprintf("Detail=%q", e.Detail))
 	}
-	if m.matchDeclarativeOnly {
+	if m.matchDeclarativeNative {
 		comma()
-		buf.WriteString(fmt.Sprintf("DeclarativeOnly=%t", e.DeclarativeOnly))
+		buf.WriteString(fmt.Sprintf("DeclarativeNative=%t", e.DeclarativeNative))
 	}
 	return "{" + buf.String() + "}"
 }
@@ -233,10 +233,10 @@ func (m ErrorMatcher) RequireOriginWhenInvalid() ErrorMatcher {
 	return m
 }
 
-// ByDeclarativeOnly returns a derived ErrorMatcher which also matches by the DeclarativeOnly
+// ByDeclarativeNative returns a derived ErrorMatcher which also matches by the DeclarativeNative
 // value of field errors.
-func (m ErrorMatcher) ByDeclarativeOnly() ErrorMatcher {
-	m.matchDeclarativeOnly = true
+func (m ErrorMatcher) ByDeclarativeNative() ErrorMatcher {
+	m.matchDeclarativeNative = true
 	return m
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/error_matcher_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/error_matcher_test.go
@@ -304,24 +304,24 @@ func TestErrorMatcher_Matches(t *testing.T) {
 		actualErr: &Error{Type: ErrorTypeRequired, Field: "field", BadValue: "value", Detail: "detail", Origin: "origin"},
 		matches:   false,
 	}, {
-		name:    "ByDeclarativeOnly: match",
-		matcher: ErrorMatcher{}.ByDeclarativeOnly(),
+		name:    "ByDeclarativeNative: match",
+		matcher: ErrorMatcher{}.ByDeclarativeNative(),
 		wantedErr: func() *Error {
 			e := baseErr()
-			e.DeclarativeOnly = true
+			e.DeclarativeNative = true
 			return e
 		},
-		actualErr: &Error{DeclarativeOnly: true},
+		actualErr: &Error{DeclarativeNative: true},
 		matches:   true,
 	}, {
-		name:    "ByDeclarativeOnly: no match",
-		matcher: ErrorMatcher{}.ByDeclarativeOnly(),
+		name:    "ByDeclarativeNative: no match",
+		matcher: ErrorMatcher{}.ByDeclarativeNative(),
 		wantedErr: func() *Error {
 			e := baseErr()
-			e.DeclarativeOnly = true
+			e.DeclarativeNative = true
 			return e
 		},
-		actualErr: &Error{DeclarativeOnly: false},
+		actualErr: &Error{DeclarativeNative: false},
 		matches:   false,
 	}, {
 		name:      "RequireOriginWhenInvalid: match",
@@ -427,15 +427,15 @@ func TestErrorMatcher_Test(t *testing.T) {
 		got:            ErrorList{Invalid(NewPath("f").Index(1).Child("a"), "v", "d")},
 		expectedErrors: []string{"expected an error matching:", "unmatched error:"},
 	}, {
-		name:    "declarative only: match",
-		matcher: ErrorMatcher{}.ByDeclarativeOnly(),
-		want:    ErrorList{{DeclarativeOnly: true}},
-		got:     ErrorList{{DeclarativeOnly: true}},
+		name:    "declarative native: match",
+		matcher: ErrorMatcher{}.ByDeclarativeNative(),
+		want:    ErrorList{{DeclarativeNative: true}},
+		got:     ErrorList{{DeclarativeNative: true}},
 	}, {
-		name:           "declarative only: no match",
-		matcher:        ErrorMatcher{}.ByDeclarativeOnly(),
-		want:           ErrorList{{DeclarativeOnly: true}},
-		got:            ErrorList{{DeclarativeOnly: false}},
+		name:           "declarative native: no match",
+		matcher:        ErrorMatcher{}.ByDeclarativeNative(),
+		want:           ErrorList{{DeclarativeNative: true}},
+		got:            ErrorList{{DeclarativeNative: false}},
 		expectedErrors: []string{"expected an error matching:", "unmatched error:"},
 	}, {
 		name:    "with origin: single match",
@@ -565,25 +565,24 @@ func TestErrorMatcher_Render(t *testing.T) {
 		},
 		{
 			name:    "with covered by declarative",
-			matcher: ErrorMatcher{}.ByDeclarativeOnly(),
+			matcher: ErrorMatcher{}.ByDeclarativeNative(),
 			err: func() *Error {
 				e := Invalid(NewPath("field"), "value", "detail")
-				e.DeclarativeOnly = true
+				e.DeclarativeNative = true
 				return e
 			}(),
-			expected: `{DeclarativeOnly=true}`,
+			expected: `{DeclarativeNative=true}`,
 		},
 		{
 			name:    "all fields with covered by declarative",
-			matcher: ErrorMatcher{}.ByType().ByField().ByValue().ByOrigin().ByDetailExact().ByDeclarativeOnly(),
+			matcher: ErrorMatcher{}.ByType().ByField().ByValue().ByOrigin().ByDetailExact().ByDeclarativeNative(),
 			err: func() *Error {
 				e := Invalid(NewPath("field"), "value", "detail").WithOrigin("origin")
-				e.DeclarativeOnly = true
+				e.DeclarativeNative = true
 				return e
 			}(),
-			expected: `{Type="Invalid value", Field="field", Value="value", Origin="origin", Detail="detail", DeclarativeOnly=true}`,
-		},
-		{
+			expected: `{Type="Invalid value", Field="field", Value="value", Origin="origin", Detail="detail", DeclarativeNative=true}`,
+		}, {
 			name:     "requireOriginWhenInvalid with origin",
 			matcher:  ErrorMatcher{}.ByOrigin().RequireOriginWhenInvalid(),
 			err:      Invalid(NewPath("field"), "value", "detail").WithOrigin("origin"),

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
@@ -56,10 +56,9 @@ type Error struct {
 	// that should also be caught by declarative validation.
 	CoveredByDeclarative bool
 
-	// DeclarativeOnly is true when this error is coming from the native
-	// declarative validations. This field is used to filer out the
-	// errors coming from declarative only validations.
-	DeclarativeOnly bool
+	// DeclarativeNative is true when this error originates from a declarative-native validation.
+	// This field is used to distinguish errors that are exclusively declarative and lack an imperative counterpart.
+	DeclarativeNative bool
 }
 
 var _ error = &Error{}
@@ -451,16 +450,16 @@ func (list ErrorList) ExtractCoveredByDeclarative() ErrorList {
 	return newList
 }
 
-// MarkDeclarativeOnly marks the error as coming from declarative only validation.
-func (e *Error) MarkDeclarativeOnly() *Error {
-	e.DeclarativeOnly = true
+// MarkDeclarativeNative marks the error as originating from a declarative-native validation.
+func (e *Error) MarkDeclarativeNative() *Error {
+	e.DeclarativeNative = true
 	return e
 }
 
-// MarkDeclarativeOnly marks all errors in the list as coming from declarative only validation.
-func (list ErrorList) MarkDeclarativeOnly() ErrorList {
+// MarkDeclarativeNative marks all errors in the list as originating from declarative-native validations.
+func (list ErrorList) MarkDeclarativeNative() ErrorList {
 	for _, err := range list {
-		err.DeclarativeOnly = true
+		err.DeclarativeNative = true
 	}
 	return list
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
@@ -75,24 +75,24 @@ func WithNormalizationRules(rules []field.NormalizationRule) ValidationConfig {
 	}
 }
 
-// WithContainsDeclarativelyOnly marks the validation configuration to indicate that it includes
+// WithDeclarativeNative marks the validation configuration to indicate that it includes
 // declarative validations that are defined *only* declaratively, lacking corresponding imperative validation.
 // When set, declarative validation is always executed regardless of feature gates. Errors marked as
-// declarative-only are separated from the full set and returned alongside imperative errors.
-func WithContainsDeclarativelyOnly() ValidationConfig {
+// declarative-native are separated from the full set and returned alongside imperative errors.
+func WithDeclarativeNative() ValidationConfig {
 	return func(config *validationConfigOption) {
-		config.containsDeclarativeOnly = true
+		config.containsDeclarativeNative = true
 	}
 }
 
 type validationConfigOption struct {
-	opType                  operation.Type
-	options                 []string
-	takeover                bool
-	subresourceGVKMapper    GroupVersionKindProvider
-	validationIdentifier    string
-	normalizationRules      []field.NormalizationRule
-	containsDeclarativeOnly bool
+	opType                    operation.Type
+	options                   []string
+	takeover                  bool
+	subresourceGVKMapper      GroupVersionKindProvider
+	validationIdentifier      string
+	normalizationRules        []field.NormalizationRule
+	containsDeclarativeNative bool
 }
 
 // validateDeclaratively validates obj and oldObj against declarative
@@ -344,10 +344,10 @@ func metricIdentifier(ctx context.Context, obj runtime.Object, opType operation.
 }
 
 // ValidateDeclarativelyWithMigrationChecks encapsulates the logic for running declarative validation.
-// It proceeds if either the DeclarativeValidation feature gate is enabled or `containsDeclarativeOnly` is set.
+// It proceeds if either the DeclarativeValidation feature gate is enabled or `containsDeclarativeNative` is set.
 // The function generates a validation identifier, runs declarative validation,
 // and conditionally compares results with imperative validation and merges errors based on the feature gate and `takeover` flag.
-// Declarative-only errors are always appended to the result.
+// Declarative-native errors are always appended to the result.
 func ValidateDeclarativelyWithMigrationChecks(ctx context.Context, scheme *runtime.Scheme, obj, oldObj runtime.Object, errs field.ErrorList, opType operation.Type, configOpts ...ValidationConfig) field.ErrorList {
 	declarativeValidationEnabled := utilfeature.DefaultFeatureGate.Enabled(features.DeclarativeValidation)
 	takeover := utilfeature.DefaultFeatureGate.Enabled(features.DeclarativeValidationTakeover)
@@ -368,23 +368,23 @@ func ValidateDeclarativelyWithMigrationChecks(ctx context.Context, scheme *runti
 		opt(cfg)
 	}
 
-	if !declarativeValidationEnabled && !cfg.containsDeclarativeOnly {
+	if !declarativeValidationEnabled && !cfg.containsDeclarativeNative {
 		return errs
 	}
 
 	// Call the panic-safe wrapper with the real validation function.
-	declarativeErrs := panicSafeValidateFunc(validateDeclaratively, cfg.takeover || cfg.containsDeclarativeOnly, cfg.validationIdentifier)(ctx, scheme, obj, oldObj, cfg)
+	declarativeErrs := panicSafeValidateFunc(validateDeclaratively, cfg.takeover || cfg.containsDeclarativeNative, cfg.validationIdentifier)(ctx, scheme, obj, oldObj, cfg)
 
 	mirroredDVErrors := field.ErrorList{}
-	dvOnlyErrors := field.ErrorList{}
-	if cfg.containsDeclarativeOnly {
+	dvNativeErrors := field.ErrorList{}
+	if cfg.containsDeclarativeNative {
 		for _, err := range declarativeErrs {
-			if err.DeclarativeOnly {
-				dvOnlyErrors = append(dvOnlyErrors, err)
+			if err.DeclarativeNative {
+				dvNativeErrors = append(dvNativeErrors, err)
 				// Internal Error is very unlikely to happen, if that happen it should be fail the validations
 				// for both of types of validations.
 			} else if err.Type == field.ErrorTypeInternal {
-				dvOnlyErrors = append(dvOnlyErrors, err)
+				dvNativeErrors = append(dvNativeErrors, err)
 				mirroredDVErrors = append(mirroredDVErrors, err)
 			} else {
 				mirroredDVErrors = append(mirroredDVErrors, err)
@@ -400,7 +400,7 @@ func ValidateDeclarativelyWithMigrationChecks(ctx context.Context, scheme *runti
 			errs = append(errs.RemoveCoveredByDeclarative(), mirroredDVErrors...)
 		}
 	}
-	errs = append(errs, dvOnlyErrors...)
+	errs = append(errs, dvNativeErrors...)
 	return errs
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go
@@ -804,70 +804,70 @@ func TestValidateDeclarativelyWithMigrationChecks(t *testing.T) {
 		field.Forbidden(field.NewPath("spec", "restartPolicy"), "imperative error covered by declarative").MarkCoveredByDeclarative(),
 	}
 	errMirroredDeclarative := field.Invalid(field.NewPath("spec", "restartPolicy"), "dec", "declarative error")
-	errDeclarativeOnly := field.Invalid(field.NewPath("spec", "replicas"), "decOnly", "declarative only error").MarkDeclarativeOnly()
+	errDeclarativeNative := field.Invalid(field.NewPath("spec", "replicas"), "decOnly", "declarative native error").MarkDeclarativeNative()
 
 	testCases := []struct {
-		name                    string
-		dvFeatureEnabled        bool
-		takeoverEnabled         bool
-		containsDeclarativeOnly bool
-		imperativeErrors        field.ErrorList
-		declarativeErrors       field.ErrorList
-		expectedErrors          field.ErrorList
-		shouldPanic             bool
+		name                      string
+		dvFeatureEnabled          bool
+		takeoverEnabled           bool
+		containsDeclarativeNative bool
+		imperativeErrors          field.ErrorList
+		declarativeErrors         field.ErrorList
+		expectedErrors            field.ErrorList
+		shouldPanic               bool
 	}{
 		{
-			name:              "Feature Disabled, Not DeclarativeOnly -> Skips declarative",
+			name:              "Feature Disabled, Not DeclarativeNative -> Skips declarative",
 			imperativeErrors:  errImperative,
 			declarativeErrors: field.ErrorList{errMirroredDeclarative},
 			expectedErrors:    errImperative,
 		},
 		{
-			name:                    "Feature Disabled, contains DeclarativeOnly -> Returns DeclarativeOnly errors, ignores regular declarative errors",
-			containsDeclarativeOnly: true,
-			imperativeErrors:        errImperative,
-			declarativeErrors:       field.ErrorList{errMirroredDeclarative, errDeclarativeOnly},
-			expectedErrors:          append(errImperative, errDeclarativeOnly),
+			name:                      "Feature Disabled, contains DeclarativeNative -> Returns DeclarativeNative errors, ignores regular declarative errors",
+			containsDeclarativeNative: true,
+			imperativeErrors:          errImperative,
+			declarativeErrors:         field.ErrorList{errMirroredDeclarative, errDeclarativeNative},
+			expectedErrors:            append(errImperative, errDeclarativeNative),
 		},
 		{
-			name:              "Feature Enabled, Not DeclarativeOnly -> Returns imperative (no takeover)",
+			name:              "Feature Enabled, Not DeclarativeNative -> Returns imperative (no takeover)",
 			dvFeatureEnabled:  true,
 			imperativeErrors:  errImperative,
 			declarativeErrors: field.ErrorList{errMirroredDeclarative},
 			expectedErrors:    errImperative,
 		},
 		{
-			name:                    "Feature Enabled, contains DeclarativeOnly -> Returns imperative + DeclarativeOnly",
-			dvFeatureEnabled:        true,
-			containsDeclarativeOnly: true,
-			imperativeErrors:        errImperative,
-			declarativeErrors:       field.ErrorList{errMirroredDeclarative, errDeclarativeOnly},
-			expectedErrors:          append(errImperative, errDeclarativeOnly),
+			name:                      "Feature Enabled, contains DeclarativeNative -> Returns imperative + DeclarativeNative",
+			dvFeatureEnabled:          true,
+			containsDeclarativeNative: true,
+			imperativeErrors:          errImperative,
+			declarativeErrors:         field.ErrorList{errMirroredDeclarative, errDeclarativeNative},
+			expectedErrors:            append(errImperative, errDeclarativeNative),
 		},
 		{
-			name:                    "Feature Enabled, takeover enabled, contains DeclarativeOnly -> Returns non mirrored imperative + declarative + DeclarativeOnly",
-			dvFeatureEnabled:        true,
-			containsDeclarativeOnly: true,
-			takeoverEnabled:         true,
-			imperativeErrors:        errImperative,
-			declarativeErrors:       field.ErrorList{errMirroredDeclarative, errDeclarativeOnly},
-			expectedErrors:          field.ErrorList{errImperative[0], errMirroredDeclarative, errDeclarativeOnly},
+			name:                      "Feature Enabled, takeover enabled, contains DeclarativeNative -> Returns non mirrored imperative + declarative + DeclarativeNative",
+			dvFeatureEnabled:          true,
+			containsDeclarativeNative: true,
+			takeoverEnabled:           true,
+			imperativeErrors:          errImperative,
+			declarativeErrors:         field.ErrorList{errMirroredDeclarative, errDeclarativeNative},
+			expectedErrors:            field.ErrorList{errImperative[0], errMirroredDeclarative, errDeclarativeNative},
 		},
 		{
-			name:                    "Feature Disabled, contains DeclarativeOnly, Panics -> Returns InternalError",
-			containsDeclarativeOnly: true,
-			imperativeErrors:        errImperative,
-			shouldPanic:             true,
-			expectedErrors:          append(errImperative, field.InternalError(nil, fmt.Errorf("panic during declarative validation: test panic"))),
+			name:                      "Feature Disabled, contains DeclarativeNative, Panics -> Returns InternalError",
+			containsDeclarativeNative: true,
+			imperativeErrors:          errImperative,
+			shouldPanic:               true,
+			expectedErrors:            append(errImperative, field.InternalError(nil, fmt.Errorf("panic during declarative validation: test panic"))),
 		},
 		{
-			name:                    "Feature Enabled, takeover enabled, contains DeclarativeOnly, InternalError -> Returns non mirrored imperative + InternalError",
-			dvFeatureEnabled:        true,
-			containsDeclarativeOnly: true,
-			takeoverEnabled:         true,
-			imperativeErrors:        errImperative,
-			declarativeErrors:       field.ErrorList{field.InternalError(nil, fmt.Errorf("internal error"))},
-			expectedErrors:          field.ErrorList{errImperative[0], field.InternalError(nil, fmt.Errorf("internal error")), field.InternalError(nil, fmt.Errorf("internal error"))},
+			name:                      "Feature Enabled, takeover enabled, contains DeclarativeNative, InternalError -> Returns non mirrored imperative + InternalError",
+			dvFeatureEnabled:          true,
+			containsDeclarativeNative: true,
+			takeoverEnabled:           true,
+			imperativeErrors:          errImperative,
+			declarativeErrors:         field.ErrorList{field.InternalError(nil, fmt.Errorf("internal error"))},
+			expectedErrors:            field.ErrorList{errImperative[0], field.InternalError(nil, fmt.Errorf("internal error")), field.InternalError(nil, fmt.Errorf("internal error"))},
 		},
 	}
 
@@ -904,8 +904,8 @@ func TestValidateDeclarativelyWithMigrationChecks(t *testing.T) {
 			copy(inputErrs, tc.imperativeErrors)
 
 			opts := []ValidationConfig{}
-			if tc.containsDeclarativeOnly {
-				opts = append(opts, WithContainsDeclarativelyOnly())
+			if tc.containsDeclarativeNative {
+				opts = append(opts, WithDeclarativeNative())
 			}
 
 			gotErrs := ValidateDeclarativelyWithMigrationChecks(ctx, localScheme, obj, nil, inputErrs, operation.Create, opts...)

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/native/basics/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/native/basics/doc_test.go
@@ -72,9 +72,9 @@ func TestMyObjectValidation(t *testing.T) {
 				return *obj
 			}(),
 			errs: field.ErrorList{
-				field.Invalid(field.NewPath("uuidField"), "invalid", "is not a valid UUID").MarkDeclarativeOnly(),
+				field.Invalid(field.NewPath("uuidField"), "invalid", "is not a valid UUID").MarkDeclarativeNative(),
 				field.Invalid(field.NewPath("uuidFieldWithoutDV"), "invalid", "is not a valid UUID"),
-				field.Invalid(field.NewPath("uuidPtrField"), "invalid", "is not a valid UUID").MarkDeclarativeOnly(),
+				field.Invalid(field.NewPath("uuidPtrField"), "invalid", "is not a valid UUID").MarkDeclarativeNative(),
 				field.Invalid(field.NewPath("uuidPtrFieldWithoutDV"), "invalid", "is not a valid UUID"),
 			},
 		},
@@ -87,7 +87,7 @@ func TestMyObjectValidation(t *testing.T) {
 				return *obj
 			}(),
 			errs: field.ErrorList{
-				field.Invalid(field.NewPath("uuidTypedefField"), UUIDString("invalid"), "is not a valid UUID").MarkDeclarativeOnly(),
+				field.Invalid(field.NewPath("uuidTypedefField"), UUIDString("invalid"), "is not a valid UUID").MarkDeclarativeNative(),
 				field.Invalid(field.NewPath("uuidTypedefFieldWithoutDV"), UUIDString("invalid"), "is not a valid UUID"),
 			},
 		},
@@ -100,7 +100,7 @@ func TestMyObjectValidation(t *testing.T) {
 				return *obj
 			}(),
 			errs: field.ErrorList{
-				field.Required(field.NewPath("stableTypeField", "innerField"), "").MarkDeclarativeOnly(),
+				field.Required(field.NewPath("stableTypeField", "innerField"), "").MarkDeclarativeNative(),
 				field.Required(field.NewPath("stableTypeFieldWithoutDV", "innerField"), ""),
 			},
 		},
@@ -113,7 +113,7 @@ func TestMyObjectValidation(t *testing.T) {
 				return *obj
 			}(),
 			errs: field.ErrorList{
-				field.TooMany(field.NewPath("stableTypeSlice"), 6, 5).MarkDeclarativeOnly(),
+				field.TooMany(field.NewPath("stableTypeSlice"), 6, 5).MarkDeclarativeNative(),
 				field.TooMany(field.NewPath("stableTypeSliceWithoutDV"), 6, 5),
 			},
 		},
@@ -126,7 +126,7 @@ func TestMyObjectValidation(t *testing.T) {
 				return *obj
 			}(),
 			errs: field.ErrorList{
-				field.Duplicate(field.NewPath("setList").Index(1), "a").MarkDeclarativeOnly(),
+				field.Duplicate(field.NewPath("setList").Index(1), "a").MarkDeclarativeNative(),
 				field.Duplicate(field.NewPath("setListWithoutDV").Index(1), "a"),
 			},
 		},
@@ -141,10 +141,10 @@ func TestMyObjectValidation(t *testing.T) {
 				return *obj
 			}(),
 			errs: field.ErrorList{
-				field.Required(field.NewPath("nestedStable", "nestedField", "innerField"), "").MarkDeclarativeOnly(),
-				field.Required(field.NewPath("nestedStable", "nestedFieldWithoutDV", "innerField"), "").MarkDeclarativeOnly(),
+				field.Required(field.NewPath("nestedStable", "nestedField", "innerField"), "").MarkDeclarativeNative(),
+				field.Required(field.NewPath("nestedStable", "nestedFieldWithoutDV", "innerField"), "").MarkDeclarativeNative(),
 				field.Required(field.NewPath("nestedStableWithoutDV", "nestedFieldWithoutDV", "innerField"), ""),
-				field.Required(field.NewPath("nestedStableWithoutDV", "nestedField", "innerField"), "").MarkDeclarativeOnly(),
+				field.Required(field.NewPath("nestedStableWithoutDV", "nestedField", "innerField"), "").MarkDeclarativeNative(),
 			},
 		},
 		{
@@ -156,7 +156,7 @@ func TestMyObjectValidation(t *testing.T) {
 				return *obj
 			}(),
 			errs: field.ErrorList{
-				field.TooLong(field.NewPath("subfieldTest", "innerField"), "abcdefg", 5).MarkDeclarativeOnly(),
+				field.TooLong(field.NewPath("subfieldTest", "innerField"), "abcdefg", 5).MarkDeclarativeNative(),
 				field.TooLong(field.NewPath("subfieldTestWithoutDV", "innerField"), "abcdefg", 5),
 			},
 		},
@@ -169,7 +169,7 @@ func TestMyObjectValidation(t *testing.T) {
 				return *obj
 			}(),
 			errs: field.ErrorList{
-				field.Invalid(field.NewPath("ipAddress"), "invalid", "is not a valid IP address").MarkDeclarativeOnly(),
+				field.Invalid(field.NewPath("ipAddress"), "invalid", "is not a valid IP address").MarkDeclarativeNative(),
 				field.Invalid(field.NewPath("ipAddressWithoutDV"), "invalid", "is not a valid IP address"),
 			},
 		},
@@ -178,7 +178,7 @@ func TestMyObjectValidation(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			st := localSchemeBuilder.Test(t)
-			st.Value(&tc.obj).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDeclarativeOnly(), tc.errs)
+			st.Value(&tc.obj).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDeclarativeNative(), tc.errs)
 		})
 	}
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/native/basics/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/native/basics/zz_generated.validations.go
@@ -57,9 +57,9 @@ func Validate_MyObject(ctx context.Context, op operation.Operation, fldPath *fie
 	// field MyObject.UUIDField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
-			// this field validations are marked declarative only
+			// this field validations are marked declarative native
 			defer func() {
-				errs = errs.MarkDeclarativeOnly()
+				errs = errs.MarkDeclarativeNative()
 			}()
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
@@ -99,9 +99,9 @@ func Validate_MyObject(ctx context.Context, op operation.Operation, fldPath *fie
 	// field MyObject.UUIDPtrField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
-			// this field validations are marked declarative only
+			// this field validations are marked declarative native
 			defer func() {
-				errs = errs.MarkDeclarativeOnly()
+				errs = errs.MarkDeclarativeNative()
 			}()
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
@@ -141,9 +141,9 @@ func Validate_MyObject(ctx context.Context, op operation.Operation, fldPath *fie
 	// field MyObject.UUIDTypedefField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *UUIDString, oldValueCorrelated bool) (errs field.ErrorList) {
-			// this field validations are marked declarative only
+			// this field validations are marked declarative native
 			defer func() {
-				errs = errs.MarkDeclarativeOnly()
+				errs = errs.MarkDeclarativeNative()
 			}()
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
@@ -169,9 +169,9 @@ func Validate_MyObject(ctx context.Context, op operation.Operation, fldPath *fie
 	// field MyObject.FieldForLength
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
-			// this field validations are marked declarative only
+			// this field validations are marked declarative native
 			defer func() {
-				errs = errs.MarkDeclarativeOnly()
+				errs = errs.MarkDeclarativeNative()
 			}()
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
@@ -205,9 +205,9 @@ func Validate_MyObject(ctx context.Context, op operation.Operation, fldPath *fie
 	// field MyObject.StableTypeField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *StableType, oldValueCorrelated bool) (errs field.ErrorList) {
-			// this field validations are marked declarative only
+			// this field validations are marked declarative native
 			defer func() {
-				errs = errs.MarkDeclarativeOnly()
+				errs = errs.MarkDeclarativeNative()
 			}()
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
@@ -233,9 +233,9 @@ func Validate_MyObject(ctx context.Context, op operation.Operation, fldPath *fie
 	// field MyObject.StableTypeFieldPointer
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *StableType, oldValueCorrelated bool) (errs field.ErrorList) {
-			// this field validations are marked declarative only
+			// this field validations are marked declarative native
 			defer func() {
-				errs = errs.MarkDeclarativeOnly()
+				errs = errs.MarkDeclarativeNative()
 			}()
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
@@ -261,9 +261,9 @@ func Validate_MyObject(ctx context.Context, op operation.Operation, fldPath *fie
 	// field MyObject.StableTypeSlice
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []StableType, oldValueCorrelated bool) (errs field.ErrorList) {
-			// this field validations are marked declarative only
+			// this field validations are marked declarative native
 			defer func() {
-				errs = errs.MarkDeclarativeOnly()
+				errs = errs.MarkDeclarativeNative()
 			}()
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
@@ -307,9 +307,9 @@ func Validate_MyObject(ctx context.Context, op operation.Operation, fldPath *fie
 	// field MyObject.SetList
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []string, oldValueCorrelated bool) (errs field.ErrorList) {
-			// this field validations are marked declarative only
+			// this field validations are marked declarative native
 			defer func() {
-				errs = errs.MarkDeclarativeOnly()
+				errs = errs.MarkDeclarativeNative()
 			}()
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
@@ -337,9 +337,9 @@ func Validate_MyObject(ctx context.Context, op operation.Operation, fldPath *fie
 	// field MyObject.NestedStable
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *NestedStableType, oldValueCorrelated bool) (errs field.ErrorList) {
-			// this field validations are marked declarative only
+			// this field validations are marked declarative native
 			defer func() {
-				errs = errs.MarkDeclarativeOnly()
+				errs = errs.MarkDeclarativeNative()
 			}()
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
@@ -365,9 +365,9 @@ func Validate_MyObject(ctx context.Context, op operation.Operation, fldPath *fie
 	// field MyObject.SubfieldTest
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *StableType, oldValueCorrelated bool) (errs field.ErrorList) {
-			// this field validations are marked declarative only
+			// this field validations are marked declarative native
 			defer func() {
-				errs = errs.MarkDeclarativeOnly()
+				errs = errs.MarkDeclarativeNative()
 			}()
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
@@ -405,9 +405,9 @@ func Validate_MyObject(ctx context.Context, op operation.Operation, fldPath *fie
 	// field MyObject.IPAddress
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
-			// this field validations are marked declarative only
+			// this field validations are marked declarative native
 			defer func() {
-				errs = errs.MarkDeclarativeOnly()
+				errs = errs.MarkDeclarativeNative()
 			}()
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
@@ -453,9 +453,9 @@ func Validate_NestedStableType(ctx context.Context, op operation.Operation, fldP
 	// field NestedStableType.NestedField
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *StableType, oldValueCorrelated bool) (errs field.ErrorList) {
-			// this field validations are marked declarative only
+			// this field validations are marked declarative native
 			defer func() {
-				errs = errs.MarkDeclarativeOnly()
+				errs = errs.MarkDeclarativeNative()
 			}()
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/native/unions/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/native/unions/doc_test.go
@@ -36,7 +36,7 @@ func TestUnionValidation(t *testing.T) {
 			name: "struct - union fails",
 			obj:  &Struct{},
 			errs: field.ErrorList{
-				field.Invalid(nil, "", "must specify one of: `unionField1`, `unionField2`").MarkDeclarativeOnly(),
+				field.Invalid(nil, "", "must specify one of: `unionField1`, `unionField2`").MarkDeclarativeNative(),
 			},
 		},
 		{
@@ -60,7 +60,7 @@ func TestUnionValidation(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				field.Invalid(field.NewPath("items"), []UnionItem{{Type: "a", A: intPtr(1)}, {Type: "b", B: intPtr(2)}}, "must specify one of: `items[{\"type\": \"a\"}]`, `items[{\"type\": \"b\"}]`").MarkDeclarativeOnly(),
+				field.Invalid(field.NewPath("items"), []UnionItem{{Type: "a", A: intPtr(1)}, {Type: "b", B: intPtr(2)}}, "must specify one of: `items[{\"type\": \"a\"}]`, `items[{\"type\": \"b\"}]`").MarkDeclarativeNative(),
 			},
 		},
 		{
@@ -87,7 +87,7 @@ func TestUnionValidation(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				field.Invalid(field.NewPath("items"), []UnionItem{{Type: "c"}}, "must specify one of: `items[{\"type\": \"a\"}]`, `items[{\"type\": \"b\"}]`").MarkDeclarativeOnly(),
+				field.Invalid(field.NewPath("items"), []UnionItem{{Type: "c"}}, "must specify one of: `items[{\"type\": \"a\"}]`, `items[{\"type\": \"b\"}]`").MarkDeclarativeNative(),
 			},
 		},
 	}
@@ -95,7 +95,7 @@ func TestUnionValidation(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			st := localSchemeBuilder.Test(t)
-			st.Value(tc.obj).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDeclarativeOnly(), tc.errs)
+			st.Value(tc.obj).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDeclarativeNative(), tc.errs)
 		})
 	}
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/native/unions/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/native/unions/zz_generated.validations.go
@@ -67,9 +67,9 @@ func Validate_ListStruct(ctx context.Context, op operation.Operation, fldPath *f
 	// field ListStruct.Items
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []UnionItem, oldValueCorrelated bool) (errs field.ErrorList) {
-			// this field validations are marked declarative only
+			// this field validations are marked declarative native
 			defer func() {
-				errs = errs.MarkDeclarativeOnly()
+				errs = errs.MarkDeclarativeNative()
 			}()
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
@@ -114,16 +114,16 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 			return false
 		}
 		return obj.UnionField2 != nil
-	}).MarkDeclarativeOnly()...)
+	}).MarkDeclarativeNative()...)
 
 	// field Struct.TypeMeta has no validation
 
 	// field Struct.UnionField1
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *int, oldValueCorrelated bool) (errs field.ErrorList) {
-			// this field validations are marked declarative only
+			// this field validations are marked declarative native
 			defer func() {
-				errs = errs.MarkDeclarativeOnly()
+				errs = errs.MarkDeclarativeNative()
 			}()
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
@@ -143,9 +143,9 @@ func Validate_Struct(ctx context.Context, op operation.Operation, fldPath *field
 	// field Struct.UnionField2
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *int, oldValueCorrelated bool) (errs field.ErrorList) {
-			// this field validations are marked declarative only
+			// this field validations are marked declarative native
 			defer func() {
-				errs = errs.MarkDeclarativeOnly()
+				errs = errs.MarkDeclarativeNative()
 			}()
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/native/zerooroneof/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/native/zerooroneof/doc_test.go
@@ -39,7 +39,7 @@ func TestZeroOrOneOfValidation(t *testing.T) {
 				Field2: intPtr(2),
 			},
 			errs: field.ErrorList{
-				field.Invalid(nil, map[string]interface{}{"field1": int(1), "field2": int(2)}, "must specify at most one of: `field1`, `field2`").MarkDeclarativeOnly(),
+				field.Invalid(nil, map[string]interface{}{"field1": int(1), "field2": int(2)}, "must specify at most one of: `field1`, `field2`").MarkDeclarativeNative(),
 			},
 		},
 		{
@@ -67,7 +67,7 @@ func TestZeroOrOneOfValidation(t *testing.T) {
 				},
 			},
 			errs: field.ErrorList{
-				field.Invalid(field.NewPath("items"), []UnionItem{{Type: "a", A: intPtr(1)}, {Type: "b", B: intPtr(2)}}, "must specify at most one of: `items[{\"type\": \"a\"}]`, `items[{\"type\": \"b\"}]`").MarkDeclarativeOnly(),
+				field.Invalid(field.NewPath("items"), []UnionItem{{Type: "a", A: intPtr(1)}, {Type: "b", B: intPtr(2)}}, "must specify at most one of: `items[{\"type\": \"a\"}]`, `items[{\"type\": \"b\"}]`").MarkDeclarativeNative(),
 			},
 		},
 		{
@@ -99,7 +99,7 @@ func TestZeroOrOneOfValidation(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			st := localSchemeBuilder.Test(t)
-			st.Value(tc.obj).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDeclarativeOnly(), tc.errs)
+			st.Value(tc.obj).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDeclarativeNative(), tc.errs)
 		})
 	}
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/native/zerooroneof/zz_generated.validations.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/native/zerooroneof/zz_generated.validations.go
@@ -67,9 +67,9 @@ func Validate_ZeroOrOneOfListStruct(ctx context.Context, op operation.Operation,
 	// field ZeroOrOneOfListStruct.Items
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []UnionItem, oldValueCorrelated bool) (errs field.ErrorList) {
-			// this field validations are marked declarative only
+			// this field validations are marked declarative native
 			defer func() {
-				errs = errs.MarkDeclarativeOnly()
+				errs = errs.MarkDeclarativeNative()
 			}()
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
@@ -114,16 +114,16 @@ func Validate_ZeroOrOneOfStruct(ctx context.Context, op operation.Operation, fld
 			return false
 		}
 		return obj.Field2 != nil
-	}).MarkDeclarativeOnly()...)
+	}).MarkDeclarativeNative()...)
 
 	// field ZeroOrOneOfStruct.TypeMeta has no validation
 
 	// field ZeroOrOneOfStruct.Field1
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *int, oldValueCorrelated bool) (errs field.ErrorList) {
-			// this field validations are marked declarative only
+			// this field validations are marked declarative native
 			defer func() {
-				errs = errs.MarkDeclarativeOnly()
+				errs = errs.MarkDeclarativeNative()
 			}()
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
@@ -143,9 +143,9 @@ func Validate_ZeroOrOneOfStruct(ctx context.Context, op operation.Operation, fld
 	// field ZeroOrOneOfStruct.Field2
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *int, oldValueCorrelated bool) (errs field.ErrorList) {
-			// this field validations are marked declarative only
+			// this field validations are marked declarative native
 			defer func() {
-				errs = errs.MarkDeclarativeOnly()
+				errs = errs.MarkDeclarativeNative()
 			}()
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/enum/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/enum/doc_test.go
@@ -57,7 +57,7 @@ func Test(t *testing.T) {
 		Enum2PtrField:   ptr.To(Enum2("x")),
 		NotEnumField:    "x",
 		NotEnumPtrField: ptr.To(NotEnum("x")),
-	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin().ByDeclarativeOnly(), field.ErrorList{
+	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin().ByDeclarativeNative(), field.ErrorList{
 		field.NotSupported(field.NewPath("enum0Field"), Enum0("x"), []Enum0{}),
 		field.NotSupported(field.NewPath("enum0PtrField"), Enum0("x"), []Enum0{}),
 		field.NotSupported(field.NewPath("enum1Field"), Enum1("x"), []Enum1{E1V1}),

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-label-key/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-label-key/doc_test.go
@@ -72,7 +72,7 @@ func Test(t *testing.T) {
 			LabelKeyField:        s,
 			LabelKeyPtrField:     ptr.To(s),
 			LabelKeyTypedefField: LabelKeyStringType(s),
-		}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin().ByDeclarativeOnly(), field.ErrorList{
+		}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin().ByDeclarativeNative(), field.ErrorList{
 			field.Invalid(field.NewPath("labelKeyField"), nil, "").WithOrigin("format=k8s-label-key"),
 			field.Invalid(field.NewPath("labelKeyPtrField"), nil, "").WithOrigin("format=k8s-label-key"),
 			field.Invalid(field.NewPath("labelKeyTypedefField"), nil, "").WithOrigin("format=k8s-label-key"),

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/zerorooneof/typedef/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/zerorooneof/typedef/doc_test.go
@@ -50,7 +50,7 @@ func Test(t *testing.T) {
 	}
 
 	st.Value(invalidBothSet).ExpectMatches(
-		field.ErrorMatcher{}.ByType().ByField().ByOrigin().ByDeclarativeOnly(),
+		field.ErrorMatcher{}.ByType().ByField().ByOrigin().ByDeclarativeNative(),
 		field.ErrorList{
 			field.Invalid(field.NewPath("tasks"), nil, "").WithOrigin("zeroOrOneOf"),
 		},

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitive_pointers/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitive_pointers/doc_test.go
@@ -52,7 +52,7 @@ func Test(t *testing.T) {
 
 	st.Value(&structA1).OldValue(&structA2).ExpectValid()
 
-	st.Value(&structA1).OldValue(&structB).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin().ByDeclarativeOnly(), field.ErrorList{
+	st.Value(&structA1).OldValue(&structB).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin().ByDeclarativeNative(), field.ErrorList{
 		field.Invalid(field.NewPath("sp"), nil, "").WithOrigin("immutable"),
 		field.Invalid(field.NewPath("ip"), nil, "").WithOrigin("immutable"),
 		field.Invalid(field.NewPath("bp"), nil, "").WithOrigin("immutable"),

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitives/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitives/doc_test.go
@@ -42,7 +42,7 @@ func Test(t *testing.T) {
 
 	st.Value(&structA).OldValue(&structA).ExpectValid()
 
-	st.Value(&structA).OldValue(&structB).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin().ByDeclarativeOnly(), field.ErrorList{
+	st.Value(&structA).OldValue(&structB).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin().ByDeclarativeNative(), field.ErrorList{
 		field.Invalid(field.NewPath("s"), nil, "").WithOrigin("immutable"),
 		field.Invalid(field.NewPath("i"), nil, "").WithOrigin("immutable"),
 		field.Invalid(field.NewPath("b"), nil, "").WithOrigin("immutable"),

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
@@ -216,7 +216,7 @@ type childNode struct {
 	node      *typeNode   // the node of the child's value type, or nil if it is in a foreign package
 
 	fieldValidations validators.Validations // validations on the field
-	// declarativeNative is true if the field only has declarative validations,
+	// declarativeNative is true if the field has declarative native validations,
 	// false if the field is being migrated and also has equivalent handwritten validation
 	declarativeNative bool
 
@@ -1260,9 +1260,9 @@ func (g *genValidations) emitValidationForChild(c *generator.Context, thisChild 
 				sw.Do("errs = append(errs,\n", targs)
 				sw.Do("  func(fldPath *$.field.Path|raw$, obj, oldObj $.fieldTypePfx$$.fieldType|raw$, oldValueCorrelated bool) (errs $.field.ErrorList|raw$) {\n", targs)
 				if fld.declarativeNative {
-					sw.Do("// this field validations are marked declarative only\n", nil)
+					sw.Do("// this field validations are marked declarative native\n", nil)
 					sw.Do("defer func() {\n", nil)
-					sw.Do("    errs = errs.MarkDeclarativeOnly()\n", nil)
+					sw.Do("    errs = errs.MarkDeclarativeNative()\n", nil)
 					sw.Do("}()\n", nil)
 				}
 				if err := sw.Merge(buf, bufsw); err != nil {
@@ -1394,7 +1394,7 @@ func emitCallsToValidators(c *generator.Context, validations []validators.Functi
 		for i, v := range validations {
 			isShortCircuit := v.Flags.IsSet(validators.ShortCircuit)
 			isNonError := v.Flags.IsSet(validators.NonError)
-			isDeclarativeOnly := v.Flags.IsSet(validators.DeclarativeOnly)
+			isDeclarativeNative := v.Flags.IsSet(validators.DeclarativeNative)
 
 			targs := generator.Args{
 				"funcName": c.Universe.Type(v.Function),
@@ -1474,8 +1474,8 @@ func emitCallsToValidators(c *generator.Context, validations []validators.Functi
 				} else {
 					sw.Do("errs = append(errs, ", nil)
 					emitCall()
-					if isDeclarativeOnly {
-						sw.Do(".MarkDeclarativeOnly()", nil)
+					if isDeclarativeNative {
+						sw.Do(".MarkDeclarativeNative()", nil)
 					}
 					sw.Do("...)\n", nil)
 				}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/union.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/union.go
@@ -328,7 +328,7 @@ func processUnionValidations(context Context, unions unions, varPrefix string,
 				extraArgs := append([]any{supportVarName, discriminatorExtractor}, extractorArgs...)
 				fn := Function(tagName, DefaultFlags, discriminatedValidator, extraArgs...)
 				if u.isDeclarative {
-					fn.Flags |= DeclarativeOnly
+					fn.Flags |= DeclarativeNative
 				}
 				result.Functions = append(result.Functions, fn)
 			} else {
@@ -338,7 +338,7 @@ func processUnionValidations(context Context, unions unions, varPrefix string,
 				extraArgs := append([]any{supportVarName}, extractorArgs...)
 				fn := Function(tagName, DefaultFlags, undiscriminatedValidator, extraArgs...)
 				if u.isDeclarative {
-					fn.Flags |= DeclarativeOnly
+					fn.Flags |= DeclarativeNative
 				}
 				result.Functions = append(result.Functions, fn)
 			}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
@@ -449,9 +449,9 @@ const (
 	// path (e.g. early return when combined with ShortCircuit).
 	NonError
 
-	// DeclarativeOnly indicates that the validation function returns an error
-	// list which should be marked as declarative-only.
-	DeclarativeOnly
+	// DeclarativeNative indicates that the validation function returns an error
+	// list which should be marked as declarative-native.
+	DeclarativeNative
 )
 
 // Conditions defines what conditions must be true for a resource to be validated.


### PR DESCRIPTION
This PR enables declarative-only validations to run even when the `DeclarativeValidation` feature gate is disabled. This is useful for cases where a validation is defined only declaratively and does not have an imperative counterpart.

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This change introduces a mechanism to support "declarative-only" validations. Previously, all declarative validations were skipped if the `DeclarativeValidation` feature gate was disabled. This PR modifies the validation logic to allow specific validations to be marked as "declarative-only," ensuring they are executed regardless of the feature gate's status.

This is achieved by:
- Adding a `WithContainsDeclarativelyOnly` option to mark a validation configuration as containing declarative-only rules.
- Updating `ValidateDeclarativelyWithMigrationChecks` to run if either the `DeclarativeValidation` feature gate is on, or if the configuration is marked as containing declarative-only rules.
- Separating declarative errors into mirrored and declarative-only errors, and ensuring the latter are always included in the final error list.

### Behavior Matrix

The following table summarizes the behavior of the validation logic based on the different combinations of the `DeclarativeValidation` and `DeclarativeValidationTakeover` feature gates and the `containsDeclarativeOnly` configuration option.

| `DeclarativeValidation` | `DeclarativeValidationTakeover` | `containsDeclarativeOnly` | Resulting Behavior |
| :--- | :--- | :--- | :--- |
| Disabled | (any) | `false` | Only imperative validation errors are returned. |
| Disabled | (any) | `true` | Imperative errors and "declarative-only" errors are returned. Mirrored declarative errors are ignored. |
| Enabled | Disabled | (any) | Imperative errors and "declarative-only" errors are returned. |
| Enabled | Enabled | `false` | Non-covered imperative errors and all declarative errors are returned. |
| Enabled | Enabled | `true` | Non-covered imperative errors, mirrored declarative errors, and "declarative-only" errors are returned. |

#### Special notes for your reviewer:

- The core logic change is in `ValidateDeclarativelyWithMigrationChecks` in `staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go`.
- New tests have been added in `TestValidateDeclarativelyWithMigrationChecks` in `staging/src/k8s.io/apiserver/pkg/registry/rest/validate_test.go` to cover the new functionality.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
