### PR TITLE
enable DV Native for PodGroups field

### DIFF
--- a/pkg/apis/scheduling/v1alpha1/zz_generated.validations.go
+++ b/pkg/apis/scheduling/v1alpha1/zz_generated.validations.go
@@ -56,10 +56,6 @@ func Validate_GangSchedulingPolicy(ctx context.Context, op operation.Operation, 
 	// field schedulingv1alpha1.GangSchedulingPolicy.MinCount
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *int32, oldValueCorrelated bool) (errs field.ErrorList) {
-			// this field validations are marked declarative native
-			defer func() {
-				errs = errs.MarkDeclarativeNative()
-			}()
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
 				return nil
@@ -86,10 +82,6 @@ func Validate_PodGroup(ctx context.Context, op operation.Operation, fldPath *fie
 	// field schedulingv1alpha1.PodGroup.Name
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *string, oldValueCorrelated bool) (errs field.ErrorList) {
-			// this field validations are marked declarative native
-			defer func() {
-				errs = errs.MarkDeclarativeNative()
-			}()
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
 				return nil
@@ -137,15 +129,11 @@ func Validate_PodGroupPolicy(ctx context.Context, op operation.Operation, fldPat
 			return false
 		}
 		return obj.Gang != nil
-	}).MarkDeclarativeNative()...)
+	})...)
 
 	// field schedulingv1alpha1.PodGroupPolicy.Basic
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *schedulingv1alpha1.BasicSchedulingPolicy, oldValueCorrelated bool) (errs field.ErrorList) {
-			// this field validations are marked declarative native
-			defer func() {
-				errs = errs.MarkDeclarativeNative()
-			}()
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
 				return nil
@@ -166,10 +154,6 @@ func Validate_PodGroupPolicy(ctx context.Context, op operation.Operation, fldPat
 	// field schedulingv1alpha1.PodGroupPolicy.Gang
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj *schedulingv1alpha1.GangSchedulingPolicy, oldValueCorrelated bool) (errs field.ErrorList) {
-			// this field validations are marked declarative native
-			defer func() {
-				errs = errs.MarkDeclarativeNative()
-			}()
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && (obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj)) {
 				return nil
@@ -306,6 +290,10 @@ func Validate_WorkloadSpec(ctx context.Context, op operation.Operation, fldPath 
 	// field schedulingv1alpha1.WorkloadSpec.PodGroups
 	errs = append(errs,
 		func(fldPath *field.Path, obj, oldObj []schedulingv1alpha1.PodGroup, oldValueCorrelated bool) (errs field.ErrorList) {
+			// this field validations are marked declarative native
+			defer func() {
+				errs = errs.MarkDeclarativeNative()
+			}()
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update && equality.Semantic.DeepEqual(obj, oldObj) {
 				return nil

--- a/pkg/apis/scheduling/validation/validation.go
+++ b/pkg/apis/scheduling/validation/validation.go
@@ -22,7 +22,6 @@ import (
 
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	pathvalidation "k8s.io/apimachinery/pkg/api/validation/path"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	apivalidation "k8s.io/kubernetes/pkg/apis/core/validation"
@@ -77,17 +76,7 @@ func validateWorkloadSpec(spec *scheduling.WorkloadSpec, fldPath *field.Path) fi
 	if spec.ControllerRef != nil {
 		allErrs = append(allErrs, validateControllerRef(spec.ControllerRef, fldPath.Child("controllerRef"))...)
 	}
-	existingPodGroups := sets.New[string]()
-	podGroupsPath := fldPath.Child("podGroups")
-	if len(spec.PodGroups) == 0 {
-		allErrs = append(allErrs, field.Required(podGroupsPath, "must have at least one item").MarkCoveredByDeclarative())
-	} else if len(spec.PodGroups) > scheduling.WorkloadMaxPodGroups {
-		allErrs = append(allErrs, field.TooMany(podGroupsPath, len(spec.PodGroups), scheduling.WorkloadMaxPodGroups).WithOrigin("maxItems").MarkCoveredByDeclarative())
-	} else {
-		for i := range spec.PodGroups {
-			allErrs = append(allErrs, validatePodGroup(&spec.PodGroups[i], podGroupsPath.Index(i), existingPodGroups)...)
-		}
-	}
+	// Validation for podGroups is handled declaratively.
 	return allErrs
 }
 
@@ -113,31 +102,6 @@ func validateControllerRef(ref *scheduling.TypedLocalObjectReference, fldPath *f
 		}
 	}
 	return allErrs
-}
-
-func validatePodGroup(podGroup *scheduling.PodGroup, fldPath *field.Path, existingPodGroups sets.Set[string]) field.ErrorList {
-	var allErrs field.ErrorList
-	if existingPodGroups.Has(podGroup.Name) {
-		// MarkCoveredByDeclarative is not needed here because the duplicate check is done.
-		allErrs = append(allErrs, field.Duplicate(fldPath, podGroup).MarkCoveredByDeclarative())
-	} else {
-		existingPodGroups.Insert(podGroup.Name)
-	}
-	allErrs = append(allErrs, validatePodGroupPolicy(&podGroup.Policy, fldPath.Child("policy"))...)
-	return allErrs
-}
-
-func validatePodGroupPolicy(policy *scheduling.PodGroupPolicy, fldPath *field.Path) field.ErrorList {
-	return nil
-}
-
-func validatBasicSchedulingPolicy(policy *scheduling.BasicSchedulingPolicy, fldPath *field.Path) field.ErrorList {
-	// BasicSchedulingPolicy has no fields.
-	return nil
-}
-
-func validateGangSchedulingPolicy(policy *scheduling.GangSchedulingPolicy, fldPath *field.Path) field.ErrorList {
-	return nil
 }
 
 // ValidateWorkloadUpdate tests if an update to Workload is valid.

--- a/pkg/apis/scheduling/validation/validation_test.go
+++ b/pkg/apis/scheduling/validation/validation_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package validation
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -260,14 +259,6 @@ func TestValidateWorkload(t *testing.T) {
 				field.Invalid(field.NewPath("spec", "controllerRef", "apiGroup"), strings.Repeat("n", 64), "a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')").MarkCoveredByDeclarative(),
 			},
 		},
-		"two pod groups with the same name": {
-			workload: mkWorkload(func(w *scheduling.Workload) {
-				w.Spec.PodGroups[1].Name = w.Spec.PodGroups[0].Name
-			}),
-			expectedErrs: field.ErrorList{
-				field.Duplicate(field.NewPath("spec", "podGroups").Index(1), scheduling.PodGroup{Name: "group1", Policy: scheduling.PodGroupPolicy{Gang: &scheduling.GangSchedulingPolicy{MinCount: 1}}}).MarkCoveredByDeclarative(),
-			},
-		},
 		"invalid controllerRef apiGroup": {
 			workload: mkWorkload(func(w *scheduling.Workload) {
 				w.Spec.ControllerRef.APIGroup = ".group"
@@ -308,33 +299,7 @@ func TestValidateWorkload(t *testing.T) {
 				field.Invalid(field.NewPath("spec", "controllerRef", "name"), "/baz", "must not contain '/'").WithOrigin("format=k8s-short-name").MarkCoveredByDeclarative(),
 			},
 		},
-		"no pod groups": {
-			workload: mkWorkload(func(w *scheduling.Workload) {
-				w.Spec.PodGroups = nil
-			}),
-			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "podGroups"), "must have at least one item").MarkCoveredByDeclarative(),
-			},
-		},
-		"too many pod groups": {
-			workload: mkWorkload(func(w *scheduling.Workload) {
-				w.Spec.PodGroups = nil
-				for i := 0; i < scheduling.WorkloadMaxPodGroups+1; i++ {
-					w.Spec.PodGroups = append(w.Spec.PodGroups, scheduling.PodGroup{
-						Name: fmt.Sprintf("group-%v", i),
-						Policy: scheduling.PodGroupPolicy{
-							Basic: &scheduling.BasicSchedulingPolicy{},
-						},
-					})
-				}
-			}),
-			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "podGroups"), scheduling.WorkloadMaxPodGroups+1, scheduling.WorkloadMaxPodGroups).WithOrigin("maxItems").MarkCoveredByDeclarative(),
-			},
-		},
-		"duplicate pod group names": {
 	}
-
 	for name, tc := range failureCases {
 		t.Run(name, func(t *testing.T) {
 			errs := ValidateWorkload(tc.workload)

--- a/pkg/registry/scheduling/workload/declarative_validation_test.go
+++ b/pkg/registry/scheduling/workload/declarative_validation_test.go
@@ -60,7 +60,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				obj.Spec.PodGroups = nil
 			}),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "podGroups"), "must have at least one item"),
+				field.Required(field.NewPath("spec", "podGroups"), "must have at least one item").MarkDeclarativeNative(),
 			},
 		},
 		"too many podGroups": {
@@ -78,7 +78,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				}
 			}),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "podGroups"), scheduling.WorkloadMaxPodGroups+1, scheduling.WorkloadMaxPodGroups).WithOrigin("maxItems"),
+				field.TooMany(field.NewPath("spec", "podGroups"), scheduling.WorkloadMaxPodGroups+1, scheduling.WorkloadMaxPodGroups).WithOrigin("maxItems").MarkDeclarativeNative(),
 			},
 		},
 		"empty podGroup name": {
@@ -116,7 +116,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 							MinCount: 1,
 						},
 					},
-				}),
+				}).MarkDeclarativeNative(),
 			},
 		},
 		// Declarative validation treats 0 as "missing" and returns Required error
@@ -319,7 +319,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				obj.Spec.PodGroups = []scheduling.PodGroup{}
 			}),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "podGroups"), "must have at least one item"),
+				field.Required(field.NewPath("spec", "podGroups"), "must have at least one item").MarkDeclarativeNative(),
 				field.Invalid(field.NewPath("spec", "podGroups"), []scheduling.PodGroup{}, "field is immutable"),
 			},
 		},
@@ -340,7 +340,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				}
 			}),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("spec", "podGroups"), scheduling.WorkloadMaxPodGroups+1, scheduling.WorkloadMaxPodGroups).WithOrigin("maxItems"),
+				field.TooMany(field.NewPath("spec", "podGroups"), scheduling.WorkloadMaxPodGroups+1, scheduling.WorkloadMaxPodGroups).WithOrigin("maxItems").MarkDeclarativeNative(),
 				field.Invalid(field.NewPath("spec", "podGroups"), nil, "field is immutable"),
 			},
 		},

--- a/staging/src/k8s.io/api/scheduling/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha1/types.go
@@ -131,6 +131,7 @@ type WorkloadSpec struct {
 	// +k8s:listType=map
 	// +k8s:listMapKey=name
 	// +k8s:maxItems=8
+	// +k8s:declarativeValidationNative
 	PodGroups []PodGroup `json:"podGroups" protobuf:"bytes,2,rep,name=podGroups"`
 }
 
@@ -169,7 +170,6 @@ type PodGroup struct {
 	// +required
 	// +k8s:required
 	// +k8s:format=k8s-short-name
-	// +k8s:declarativeValidationNative
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
 
 	// Policy defines the scheduling policy for this PodGroup.
@@ -187,7 +187,6 @@ type PodGroupPolicy struct {
 	// +k8s:optional
 	// +oneOf=PolicySelection
 	// +k8s:unionMember
-	// +k8s:declarativeValidationNative
 	Basic *BasicSchedulingPolicy `json:"basic,omitempty" protobuf:"bytes,2,opt,name=basic"`
 
 	// Gang specifies that the pods in this group should be scheduled using
@@ -197,7 +196,6 @@ type PodGroupPolicy struct {
 	// +k8s:optional
 	// +oneOf=PolicySelection
 	// +k8s:unionMember
-	// +k8s:declarativeValidationNative
 	Gang *GangSchedulingPolicy `json:"gang,omitempty" protobuf:"bytes,3,opt,name=gang"`
 }
 
@@ -219,6 +217,5 @@ type GangSchedulingPolicy struct {
 	// +required
 	// +k8s:required
 	// +k8s:minimum=0
-	// +k8s:declarativeValidationNative
 	MinCount int32 `json:"minCount" protobuf:"varint,1,opt,name=minCount"`
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR refactors the `Workload` resource validation by promoting manual validation for `PodGroups` to the native declarative validation system. By adding the `+k8s:declarativeValidationNative` marker to the `PodGroups` field in the API types, we enable the generator to handle constraints like `minItems`, `maxItems`, and child field validations. This allows for the removal of significant manual validation code and associated unit tests, reducing maintenance overhead and ensuring consistency with Kubernetes declarative validation standards.

#### Commits:
*   **Refactor Workload: add native validation for GangSchedulingPolicy.MinCount**: Implements native validation for the `MinCount` field within gang scheduling policies.
*   **Refactor Workload: add native validation for PodGroupPolicy**: Implements native validation for the `PodGroupPolicy` union.
*   **Refactor Workload: add native validation for PodGroups**: Completes the transition by applying native validation to the `PodGroups` list in `WorkloadSpec`.

#### Changes:
*   **`staging/src/k8s.io/api/scheduling/v1alpha1/types.go`**: Added the `+k8s:declarativeValidationNative` marker to the `PodGroups` field in `WorkloadSpec`.
*   **`pkg/apis/scheduling/validation/validation.go`**: Removed manual validation functions including `validatePodGroup`, `validatePodGroupPolicy`, and `validateGangSchedulingPolicy`.
*   **`pkg/apis/scheduling/validation/validation_test.go`**: Removed manual validation test cases that are now covered by declarative tests.
*   **`pkg/registry/scheduling/workload/declarative_validation_test.go`**: Updated tests to verify that validation errors are correctly flagged as `MarkDeclarativeNative()`.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:
review this PR, commit by commit.

#### Does this PR introduce a user-facing change?
NONE