### PR TITLE
rename opaqueType tag to opaque

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/cross_pkg/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/cross_pkg/doc.go
@@ -68,55 +68,55 @@ type T1 struct {
 	TypedefsE4Ptr *typedefs.E4 `json:"typedefse4Ptr"`
 
 	// +k8s:validateTrue="field T1.OtherString"
-	// +k8s:opaqueType
+	// +k8s:opaque
 	OtherString other.StringType `json:"otherString"`
 	// +k8s:validateTrue="field T1.OtherStringPtr"
-	// +k8s:opaqueType
+	// +k8s:opaque
 	OtherStringPtr *other.StringType `json:"otherStringPtr"`
 	// +k8s:validateTrue="field T1.OtherInt"
-	// +k8s:opaqueType
+	// +k8s:opaque
 	OtherInt other.IntType `json:"otherInt"`
 	// +k8s:validateTrue="field T1.OtherIntPtr"
-	// +k8s:opaqueType
+	// +k8s:opaque
 	OtherIntPtr *other.IntType `json:"otherIntPtr"`
 	// +k8s:validateTrue="field T1.OtherStruct"
-	// +k8s:opaqueType
+	// +k8s:opaque
 	OtherStruct other.StructType `json:"otherStruct"`
 	// +k8s:validateTrue="field T1.OtherStructPtr"
-	// +k8s:opaqueType
+	// +k8s:opaque
 	OtherStructPtr *other.StructType `json:"otherStructPtr"`
 
 	// +k8s:validateTrue="field T1.SliceOfOtherStruct"
 	// +k8s:eachVal=+k8s:validateTrue="field T1.SliceOfOtherStruct values"
-	// +k8s:eachVal=+k8s:opaqueType
+	// +k8s:eachVal=+k8s:opaque
 	SliceOfOtherStruct []other.StructType `json:"sliceOfOtherStruct"`
 
 	// +k8s:validateTrue="field T1.ListMapOfOtherStruct"
 	// +k8s:eachVal=+k8s:validateTrue="field T1.SliceOfOtherStruct values"
 	// +k8s:listType=map
 	// +k8s:listMapKey=stringField
-	// +k8s:eachVal=+k8s:opaqueType
+	// +k8s:eachVal=+k8s:opaque
 	ListMapOfOtherStruct []other.StructType `json:"listMapOfOtherStruct"`
 
 	// +k8s:validateTrue="field T1.MapOfOtherStringToOtherStruct"
 	// +k8s:eachKey=+k8s:validateTrue="field T1.MapOfOtherStringToOtherStruct keys"
 	// +k8s:eachVal=+k8s:validateTrue="field T1.MapOfOtherStringToOtherStruct values"
-	// +k8s:eachKey=+k8s:opaqueType
-	// +k8s:eachVal=+k8s:opaqueType
+	// +k8s:eachKey=+k8s:opaque
+	// +k8s:eachVal=+k8s:opaque
 	MapOfOtherStringToOtherStruct map[other.StringType]other.StructType `json:"mapOfOtherStringToOtherStruct"`
 }
 
 // TODO: the validateFalse test fixture doesn't handle map and slice types, and
 // fixing it requires fixing randfill.  That is a tomorrow problem.  For now, the
-// following types have been tested to fail without +k8s:opaqueType.
+// following types have been tested to fail without +k8s:opaque.
 
 /*
 // +k8s:validateTrue="type TypedefSliceOther"
-// +k8s:eachVal=+k8s:opaqueType
+// +k8s:eachVal=+k8s:opaque
 type TypedefSliceOther []other.StructType
 
 // +k8s:validateTrue="type TypedefMapOther"
-// +k8s:eachKey=+k8s:opaqueType
-// +k8s:eachVal=+k8s:opaqueType
+// +k8s:eachKey=+k8s:opaque
+// +k8s:eachVal=+k8s:opaque
 type TypedefMapOther map[other.StringType]other.StructType
 */

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/opaque/doc.go
@@ -37,12 +37,12 @@ type Struct struct {
 	StructPtrField *OtherStruct `json:"structPtrField"`
 
 	// +k8s:validateFalse="field Struct.OpaqueStructField"
-	// +k8s:opaqueType
+	// +k8s:opaque
 	OpaqueStructField OtherStruct `json:"opaqueStructField"`
 
 	// +k8s:validateFalse="field Struct.OpaqueStructPtrField"
 	// +k8s:required
-	// +k8s:opaqueType
+	// +k8s:opaque
 	OpaqueStructPtrField *OtherStruct `json:"opaqueStructPtrField"`
 
 	// +k8s:validateFalse="field Struct.SliceOfStructField"
@@ -51,7 +51,7 @@ type Struct struct {
 
 	// +k8s:validateFalse="field Struct.SliceOfOpaqueStructField"
 	// +k8s:eachVal=+k8s:validateFalse="field Struct.SliceOfOpaqueStructField vals"
-	// +k8s:eachVal=+k8s:opaqueType
+	// +k8s:eachVal=+k8s:opaque
 	SliceOfOpaqueStructField []OtherStruct `json:"sliceOfOpaqueStructField"`
 
 	// +k8s:validateFalse="field Struct.ListMapOfStructField"
@@ -64,7 +64,7 @@ type Struct struct {
 	// +k8s:eachVal=+k8s:validateFalse="field Struct.ListMapOfOpaqueStructField vals"
 	// +k8s:listType=map
 	// +k8s:listMapKey=stringField
-	// +k8s:eachVal=+k8s:opaqueType
+	// +k8s:eachVal=+k8s:opaque
 	ListMapOfOpaqueStructField []OtherStruct `json:"listMapOfOpaqueStructField"`
 
 	// +k8s:validateFalse="field Struct.MapOfStringToStructField"
@@ -75,8 +75,8 @@ type Struct struct {
 	// +k8s:validateFalse="field Struct.MapOfStringToOpaqueStructField"
 	// +k8s:eachKey=+k8s:validateFalse="field Struct.MapOfStringToOpaqueStructField keys"
 	// +k8s:eachVal=+k8s:validateFalse="field Struct.MapOfStringToOpaqueStructField vals"
-	// +k8s:eachKey=+k8s:opaqueType
-	// +k8s:eachVal=+k8s:opaqueType
+	// +k8s:eachKey=+k8s:opaque
+	// +k8s:eachVal=+k8s:opaque
 	MapOfStringToOpaqueStructField map[OtherString]OtherStruct `json:"mapOfStringToOpaqueStructField"`
 }
 
@@ -92,13 +92,13 @@ type OtherString string
 // TODO: the validateFalse test fixture doesn't handle map and slice types, and
 // fixing it requires fixing randfill.  That is a tomorrow problem.  For now, the
 // following types have been tested to generate correct code with
-// +k8s:opaqueType.
+// +k8s:opaque.
 
 // +k8s:validateTrue="type TypedefSliceOther"
-// +k8s:eachVal=+k8s:opaqueType
+// +k8s:eachVal=+k8s:opaque
 type TypedefSliceOther []OtherStruct
 
 // +k8s:validateTrue="type TypedefMapOther"
-// +k8s:eachKey=+k8s:opaqueType
-// +k8s:eachVal=+k8s:opaqueType
+// +k8s:eachKey=+k8s:opaque
+// +k8s:eachVal=+k8s:opaque
 type TypedefMapOther map[OtherString]OtherStruct

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/nonincluded/doc.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/nonincluded/doc.go
@@ -29,6 +29,6 @@ var localSchemeBuilder = testscheme.New()
 
 type Struct struct {
 	// +k8s:subfield(stringField)=+k8s:validateFalse="subfield Struct.(other.StructType).StringField"
-	// +k8s:opaqueType
+	// +k8s:opaque
 	other.StructType
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation.go
@@ -438,13 +438,13 @@ func (td *typeDiscoverer) discoverType(t *types.Type, fldPath *field.Path) (*typ
 			case types.Slice:
 				// Validate each value.
 				if elemNode := underlying.node.elem.node; elemNode == nil {
-					if !thisNode.typeValidations.OpaqueValType {
+					if !thisNode.typeValidations.OpaqueVal {
 						return nil, fmt.Errorf("%v: value type %v is in a non-included package; "+
 							"either add this package to validation-gen's --readonly-pkg flag, "+
-							"or add +k8s:eachVal=+k8s:opaqueType to the field to skip validation",
+							"or add +k8s:eachVal=+k8s:opaque to the field to skip validation",
 							fldPath, underlying.node.elem.childType)
 					}
-				} else if thisNode.typeValidations.OpaqueValType {
+				} else if thisNode.typeValidations.OpaqueVal {
 					// If the type is marked as opaque, we can treat it as it is
 					// were in a non-included package.
 				} else {
@@ -470,13 +470,13 @@ func (td *typeDiscoverer) discoverType(t *types.Type, fldPath *field.Path) (*typ
 			case types.Map:
 				// Validate each key.
 				if keyNode := underlying.node.key.node; keyNode == nil {
-					if !thisNode.typeValidations.OpaqueKeyType {
+					if !thisNode.typeValidations.OpaqueKey {
 						return nil, fmt.Errorf("%v: key type %v is in a non-included package; "+
 							"either add this package to validation-gen's --readonly-pkg flag, "+
-							"or add +k8s:eachKey=+k8s:opaqueType to the field to skip validation",
+							"or add +k8s:eachKey=+k8s:opaque to the field to skip validation",
 							fldPath, underlying.node.elem.childType)
 					}
-				} else if thisNode.typeValidations.OpaqueKeyType {
+				} else if thisNode.typeValidations.OpaqueKey {
 					// If the type is marked as opaque, we can treat it as it is
 					// were in a non-included package.
 				} else {
@@ -501,13 +501,13 @@ func (td *typeDiscoverer) discoverType(t *types.Type, fldPath *field.Path) (*typ
 				}
 				// Validate each value.
 				if elemNode := underlying.node.elem.node; elemNode == nil {
-					if !thisNode.typeValidations.OpaqueValType {
+					if !thisNode.typeValidations.OpaqueVal {
 						return nil, fmt.Errorf("%v: value type %v is in a non-included package; "+
 							"either add this package to validation-gen's --readonly-pkg flag, "+
-							"or add +k8s:eachVal=+k8s:opaqueType to the field to skip validation",
+							"or add +k8s:eachVal=+k8s:opaque to the field to skip validation",
 							fldPath, underlying.node.elem.childType)
 					}
-				} else if thisNode.typeValidations.OpaqueValType {
+				} else if thisNode.typeValidations.OpaqueVal {
 					// If the type is marked as opaque, we can treat it as it is
 					// were in a non-included package.
 				} else {
@@ -684,13 +684,13 @@ func (td *typeDiscoverer) discoverStruct(thisNode *typeNode, fldPath *field.Path
 		switch util.NonPointer(childType).Kind {
 		case types.Struct, types.Alias:
 			if child.node == nil { // a non-included type
-				if !child.fieldValidations.OpaqueType {
+				if !child.fieldValidations.Opaque {
 					return fmt.Errorf("%v: type %v is in a non-included package; "+
 						"either add this package to validation-gen's --readonly-pkg flag, "+
-						"or add +k8s:opaqueType to the field to skip validation",
+						"or add +k8s:opaque to the field to skip validation",
 						childPath, childType.String())
 				}
-			} else if child.fieldValidations.OpaqueType {
+			} else if child.fieldValidations.Opaque {
 				// If the field is marked as opaque, we can treat it as it is
 				// were in a non-included package.
 				child.node = nil
@@ -708,13 +708,13 @@ func (td *typeDiscoverer) discoverStruct(thisNode *typeNode, fldPath *field.Path
 		case types.Slice:
 			// Validate each value of a list field.
 			if elemNode := child.node.elem.node; elemNode == nil {
-				if !child.fieldValidations.OpaqueValType {
+				if !child.fieldValidations.OpaqueVal {
 					return fmt.Errorf("%v: value type %v is in a non-included package; "+
 						"either add this package to validation-gen's --readonly-pkg flag, "+
-						"or add +k8s:eachVal=+k8s:opaqueType to the field to skip validation",
+						"or add +k8s:eachVal=+k8s:opaque to the field to skip validation",
 						childPath, childType.Elem.String())
 				}
-			} else if child.fieldValidations.OpaqueValType {
+			} else if child.fieldValidations.OpaqueVal {
 				// If the field is marked as opaque, we can treat it as it is
 				// were in a non-included package.
 			} else {
@@ -740,13 +740,13 @@ func (td *typeDiscoverer) discoverStruct(thisNode *typeNode, fldPath *field.Path
 		case types.Map:
 			// Validate each key of a map field.
 			if keyNode := child.node.key.node; keyNode == nil {
-				if !child.fieldValidations.OpaqueKeyType {
+				if !child.fieldValidations.OpaqueKey {
 					return fmt.Errorf("%v: key type %v is in a non-included package; "+
 						"either add this package to validation-gen's --readonly-pkg flag, "+
-						"or add +k8s:eachKey=+k8s:opaqueType to the field to skip validation",
+						"or add +k8s:eachKey=+k8s:opaque to the field to skip validation",
 						childPath, childType.Key.String())
 				}
-			} else if child.fieldValidations.OpaqueKeyType {
+			} else if child.fieldValidations.OpaqueKey {
 				// If the field is marked as opaque, we can treat it as it is
 				// were in a non-included package.
 			} else {
@@ -771,13 +771,13 @@ func (td *typeDiscoverer) discoverStruct(thisNode *typeNode, fldPath *field.Path
 			}
 			// Validate each value of a map field.
 			if elemNode := child.node.elem.node; elemNode == nil {
-				if !child.fieldValidations.OpaqueValType {
+				if !child.fieldValidations.OpaqueVal {
 					return fmt.Errorf("%v: value type %v is in a non-included package; "+
 						"either add this package to validation-gen's --readonly-pkg flag, "+
-						"or add +k8s:eachVal=+k8s:opaqueType to the field to skip validation",
+						"or add +k8s:eachVal=+k8s:opaque to the field to skip validation",
 						childPath, childType.Elem.String())
 				}
-			} else if child.fieldValidations.OpaqueValType {
+			} else if child.fieldValidations.OpaqueVal {
 				// If the field is marked as opaque, we can treat it as it is
 				// were in a non-included package.
 			} else {

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validation_tags.md
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validation_tags.md
@@ -20,7 +20,7 @@ This document lists the supported validation tags and their related information.
 | [`k8s:maxItems`](#k8smaxitems) | k8s:maxItems=\<non-negative integer\> | N/A | Indicates that a list field has a limit on its size. | list values, map values, struct fields, type definitions |
 | [`k8s:maxLength`](#k8smaxlength) | k8s:maxLength=\<non-negative integer\> | N/A | Indicates that a string field has a limit on its length. | anywhere |
 | [`k8s:minimum`](#k8sminimum) | k8s:minimum=\<integer\> | N/A | Indicates that a numeric field has a minimum value. | anywhere |
-| [`k8s:opaqueType`](#k8sopaquetype) | k8s:opaqueType | N/A | Indicates that any validations declared on the referenced type will be ignored. If a referenced type's package is not included in the generator's current flags, this tag must be set, or code generation will fail (preventing silent mistakes). If the validations should not be ignored, add the type's package to the generator using the --readonly-pkg flag. | struct fields |
+| [`k8s:opaque`](#k8sopaquetype) | k8s:opaque | N/A | Indicates that any validations declared on the referenced type will be ignored. If a referenced type's package is not included in the generator's current flags, this tag must be set, or code generation will fail (preventing silent mistakes). If the validations should not be ignored, add the type's package to the generator using the --readonly-pkg flag. | struct fields |
 | [`k8s:optional`](#k8soptional) | k8s:optional | N/A | Indicates that a field is optional to clients. | struct fields |
 | [`k8s:required`](#k8srequired) | k8s:required | N/A | Indicates that a field must be specified by clients. | struct fields |
 | [`k8s:subfield`](#k8ssubfield) | k8s:subfield(\<field-json-name\>)=\<validation-tag\> | <field-json-name> | Declares a validation for a subfield of a struct. | anywhere |
@@ -137,7 +137,7 @@ null
 |-------------|------|---------|
 | **\<integer\>** | This field must be greater than or equal to x. | None |
 
-### k8s:opaqueType
+### k8s:opaque
 
 #### Payloads
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/each.go
@@ -107,7 +107,7 @@ func (evtv eachValTagValidator) GetValidations(context Context, tag codetags.Tag
 	if validations, err := evtv.validator.ExtractValidations(elemContext, *tag.ValueTag); err != nil {
 		return Validations{}, err
 	} else {
-		if validations.Empty() && !validations.OpaqueKeyType && !validations.OpaqueValType && !validations.OpaqueType {
+		if validations.Empty() && !validations.OpaqueKey && !validations.OpaqueVal && !validations.Opaque {
 			return Validations{}, fmt.Errorf("no validation functions found")
 		}
 		if len(validations.Variables) > 0 {
@@ -143,7 +143,7 @@ func ForEachVal(fldPath *field.Path, t *types.Type, fn FunctionGen) (Validations
 // typedef to a list, this is the alias type, not the underlying type.
 func (evtv eachValTagValidator) getListValidations(fldPath *field.Path, t *types.Type, validations Validations) (Validations, error) {
 	result := Validations{}
-	result.OpaqueValType = validations.OpaqueType
+	result.OpaqueVal = validations.Opaque
 
 	// This type is a "late" validator, so it runs after all the keys are
 	// registered.  See LateTagValidator() above.
@@ -206,7 +206,7 @@ func (evtv eachValTagValidator) getListValidations(fldPath *field.Path, t *types
 // typedef to a map, this is the alias type, not the underlying type.
 func (evtv eachValTagValidator) getMapValidations(t *types.Type, validations Validations) (Validations, error) {
 	result := Validations{}
-	result.OpaqueValType = validations.OpaqueType
+	result.OpaqueVal = validations.Opaque
 
 	nt := util.NativeType(t)
 	equivArg := Identifier(validateSemanticDeepEqual)
@@ -289,7 +289,7 @@ func (ektv eachKeyTagValidator) GetValidations(context Context, tag codetags.Tag
 func (ektv eachKeyTagValidator) getValidations(t *types.Type, validations Validations) (Validations, error) {
 	nt := util.NativeType(t)
 	result := Validations{}
-	result.OpaqueKeyType = validations.OpaqueType
+	result.OpaqueKey = validations.Opaque
 	for _, vfn := range validations.Functions {
 		comm := vfn.Comments
 		vfn.Comments = nil

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/opaque.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/opaque.go
@@ -22,32 +22,32 @@ import (
 )
 
 const (
-	opaqueTypeTagName = "k8s:opaqueType"
+	opaqueTagName = "k8s:opaque"
 )
 
-type opaqueTypeTagValidator struct{}
+type opaqueTagValidator struct{}
 
 func init() {
-	RegisterTagValidator(opaqueTypeTagValidator{})
+	RegisterTagValidator(opaqueTagValidator{})
 }
 
-func (opaqueTypeTagValidator) Init(Config) {}
+func (opaqueTagValidator) Init(Config) {}
 
-func (opaqueTypeTagValidator) TagName() string {
-	return opaqueTypeTagName
+func (opaqueTagValidator) TagName() string {
+	return opaqueTagName
 }
 
-func (opaqueTypeTagValidator) ValidScopes() sets.Set[Scope] {
+func (opaqueTagValidator) ValidScopes() sets.Set[Scope] {
 	return sets.New(ScopeType, ScopeField, ScopeListVal, ScopeMapKey, ScopeMapVal)
 }
 
-func (opaqueTypeTagValidator) GetValidations(_ Context, _ codetags.Tag) (Validations, error) {
-	return Validations{OpaqueType: true}, nil
+func (opaqueTagValidator) GetValidations(_ Context, _ codetags.Tag) (Validations, error) {
+	return Validations{Opaque: true}, nil
 }
 
-func (opaqueTypeTagValidator) Docs() TagDoc {
+func (opaqueTagValidator) Docs() TagDoc {
 	doc := TagDoc{
-		Tag:            opaqueTypeTagName,
+		Tag:            opaqueTagName,
 		StabilityLevel: Alpha,
 		Scopes:         []Scope{ScopeField},
 		Description: "Indicates that any validations declared on the referenced type will be ignored. " +

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/validators.go
@@ -384,18 +384,18 @@ type Validations struct {
 	// Comments holds comments to emit (without the leading "//").
 	Comments []string
 
-	// OpaqueType indicates that the type being validated is opaque, and that
+	// Opaque indicates that the type being validated is opaque, and that
 	// any validations defined on it should not be emitted.
-	OpaqueType bool
+	Opaque bool
 
-	// OpaqueKeyType indicates that the key type of a map being validated is
+	// OpaqueKey indicates that the key type of a map being validated is
 	// opaque, and that any validations defined on it should not be emitted.
-	OpaqueKeyType bool
+	OpaqueKey bool
 
-	// OpaqueValType indicates that the key type of a map or slice being
+	// OpaqueVal indicates that the key type of a map or slice being
 	// validated is opaque, and that any validations defined on it should not
 	// be emitted.
-	OpaqueValType bool
+	OpaqueVal bool
 }
 
 func (v *Validations) Empty() bool {
@@ -422,9 +422,9 @@ func (v *Validations) Add(o Validations) {
 	v.Functions = append(v.Functions, o.Functions...)
 	v.Variables = append(v.Variables, o.Variables...)
 	v.Comments = append(v.Comments, o.Comments...)
-	v.OpaqueType = v.OpaqueType || o.OpaqueType
-	v.OpaqueKeyType = v.OpaqueKeyType || o.OpaqueKeyType
-	v.OpaqueValType = v.OpaqueValType || o.OpaqueValType
+	v.Opaque = v.Opaque || o.Opaque
+	v.OpaqueKey = v.OpaqueKey || o.OpaqueKey
+	v.OpaqueVal = v.OpaqueVal || o.OpaqueVal
 }
 
 // FunctionFlags define optional properties of a validator.  Most validators


### PR DESCRIPTION
#### What this PR does / why we need it:

Renames `opaqueType` tag to `opaque`

#### Which issue(s) this PR is related to:

Fixes #116